### PR TITLE
vulnerability XSS fix

### DIFF
--- a/templates/parts/lists/search_list.html.twig
+++ b/templates/parts/lists/search_list.html.twig
@@ -16,7 +16,7 @@
             </div>
             <div id="searchInfo" class="accordion-collapse collapse" data-bs-parent="#listAccordion">
                 <div class="accordion-body">
-                    <h4>{% trans with {"%keyword%": keyword} %}parts_list.search.searching_for{% endtrans %}</h4>
+                    <h4>{% trans with {"%keyword%": keyword|escape} %}parts_list.search.searching_for{% endtrans %}</h4>
                     {% trans %}parts_list.search_options.caption{% endtrans %}:
 
 


### PR DESCRIPTION
The "trans with" command is not automatically escaping the string, so this is a XSS (Cross-Site Scripting) vulnerability. Tested string: https://URL-TO-PART-DB-SERVER/de/parts/search?keyword=%22'%3E%3Cqss%20a%3D X147208852Y1_1Z%3E

QUALYS Enterprise WAS Scan Report classifies this as level 5 security risk