### PR TITLE
vulnerability Path-relative stylesheet import (PRSSI) fix

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    
+    <base href="{{ app.request.getSchemeAndHttpHost() }}">
 
     <link rel="manifest" href="{{ asset('manifest.json') }}">
 


### PR DESCRIPTION
Threat
Relative URLs can be dangerous since browser may not determine the correct directory. If the HTML uses path-relative CSS links, it may be susceptible to pathrelative stylesheet import (PRSSI) vulnerabilities. This could allow an attacker to take advantage of CSS imports with relative URLs by overwriting their target file.

Impact
An attacker may trick browsers into importing JavaScript or HTML code as a stylesheet. This has been shown to enable a number of different attacks, including cross-site scripting (XSS) and exfiltration of CSRF tokens.

Solution
It is recommended to use absolute URLs for CSS imports. Alternately you can add the HTML "base" tag in the document which defines the base URL or target location for all the relative URLs.
The vulnerability can also be mitigated by using the following best practices to harden the web pages: • Set a DOCTYPE which does not allow Quirks mode as explained at https://hsivonen.fi/doctype/ • Set response header X-Frame-Options: deny
• Set response header X-Content-Type-Options: nosniff.

-----------
To me the easiest way to fix this, was adding the base URL. :)