### PR TITLE
Update installation_guide-debian.md

### DIFF
--- a/docs/installation/installation_guide-debian.md
+++ b/docs/installation/installation_guide-debian.md
@@ -101,7 +101,7 @@ The basic configuration of Part-DB is done by a `.env.local` file in the main di
 cp .env .env.local
 ```
 
-In your `.env.local` you can configure Part-DB according to your wishes. A full list of configuration options can be found [here]({% link configuration.md %}.
+In your `.env.local` you can configure Part-DB according to your wishes. A full list of configuration options can be found [here](../configuration.md).
 Other configuration options like the default language or default currency can be found in `config/parameters.yaml`.
 
 Please check that the `partdb.default_currency` value in `config/parameters.yaml` matches your mainly used currency, as this can not be changed after creating price informations.


### PR DESCRIPTION
Fixed a typo: (link to configuration.md) - sorry for this trivial change, just getting the hang of this -  the old link might work in jekyll or something, but doesn't work in the online docs (https://docs.part-db.de/installation/installation_guide-debian.html#create-configuration-for-part-db). 