### PR TITLE
Fix RegEx to handle negative values and Ohms without prefix

### DIFF
--- a/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
+++ b/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
@@ -106,7 +106,7 @@ class ParameterDTO
      */
     public static function splitIntoValueAndUnit(string $value): ?array
     {
-       if (preg_match('/^(?<value>[0-9.]+)\s*(?<unit>[°℃a-zA-Z_]+\s?\w{0,4})$/u', $value, $matches)) {
+       if (preg_match('/^(?<value>-?[0-9.]+)\s*(?<unit>[°℃a-zA-Z_]+\s?\w{0,4})$/u', $value, $matches)) {
            $value = $matches['value'];
            $unit = $matches['unit'];
 

--- a/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
+++ b/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
@@ -106,7 +106,7 @@ class ParameterDTO
      */
     public static function splitIntoValueAndUnit(string $value): ?array
     {
-       if (preg_match('/^(?<value>-?[0-9.]+)\s*(?<unit>[%Ω°℃a-zA-Z_]+\s?\w{0,4})$/u', $value, $matches)) {
+       if (preg_match('/^(?<value>-?[0-9\.]+)\s*(?<unit>[%Ω°℃a-z_\/]+\s?\w{0,4})$/iu', $value, $matches)) {
            $value = $matches['value'];
            $unit = $matches['unit'];
 

--- a/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
+++ b/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
@@ -106,7 +106,7 @@ class ParameterDTO
      */
     public static function splitIntoValueAndUnit(string $value): ?array
     {
-       if (preg_match('/^(?<value>-?[0-9.]+)\s*(?<unit>[Ω°℃a-zA-Z_]+\s?\w{0,4})$/u', $value, $matches)) {
+       if (preg_match('/^(?<value>-?[0-9.]+)\s*(?<unit>[%Ω°℃a-zA-Z_]+\s?\w{0,4})$/u', $value, $matches)) {
            $value = $matches['value'];
            $unit = $matches['unit'];
 

--- a/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
+++ b/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
@@ -106,7 +106,7 @@ class ParameterDTO
      */
     public static function splitIntoValueAndUnit(string $value): ?array
     {
-       if (preg_match('/^(?<value>-?[0-9.]+)\s*(?<unit>[°℃a-zA-Z_]+\s?\w{0,4})$/u', $value, $matches)) {
+       if (preg_match('/^(?<value>-?[0-9.]+)\s*(?<unit>[Ω°℃a-zA-Z_]+\s?\w{0,4})$/u', $value, $matches)) {
            $value = $matches['value'];
            $unit = $matches['unit'];
 

--- a/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
@@ -288,7 +288,7 @@ class LCSCProvider implements InfoProviderInterface
             } elseif (str_starts_with($attribute['paramValueEn'], '±')) {
               [$number, $unit] = ParameterDTO::splitIntoValueAndUnit(ltrim($attribute['paramValueEn'], " ±")) ?? [$attribute['paramValueEn'], null];
               if (is_numeric($number)) {
-                $result[] = new ParameterDTO(name: $attribute['paramNameEn'], value_min: (float) $number, value_max: (float) $number, unit: $unit, group: null);
+                $result[] = new ParameterDTO(name: $attribute['paramNameEn'], value_min: -abs((float) $number), value_max: abs((float) $number), unit: $unit, group: null);
                 continue;
               }
             }

--- a/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
@@ -286,7 +286,7 @@ class LCSCProvider implements InfoProviderInterface
                 }
             //If it's a plus/minus value, we'll also it like a range
             } elseif (str_starts_with($attribute['paramValueEn'], '±')) {
-              [$number, $unit] = ParameterDTO::splitIntoValueAndUnit(ltrim($parts[0], " ±")) ?? [$attribute['paramValueEn'], null];
+              [$number, $unit] = ParameterDTO::splitIntoValueAndUnit(ltrim($attribute['paramValueEn'], " ±")) ?? [$attribute['paramValueEn'], null];
               if (is_numeric($number)) {
                 $result[] = new ParameterDTO(name: $attribute['paramNameEn'], value_min: (float) $number, value_max: (float) $number, unit: $unit, group: null);
                 continue;

--- a/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
@@ -284,6 +284,13 @@ class LCSCProvider implements InfoProviderInterface
                         continue;
                     }
                 }
+            //If it's a plus/minus value, we'll also it like a range
+            } elseif (str_starts_with($attribute['paramValueEn'], '±')) {
+              [$number, $unit] = ParameterDTO::splitIntoValueAndUnit(ltrim($parts[0], " ±")) ?? [$attribute['paramValueEn'], null];
+              if (is_numeric($number)) {
+                $result[] = new ParameterDTO(name: $attribute['paramNameEn'], value_min: (float) $number, value_max: (float) $number, unit: $unit, group: null);
+                continue;
+              }
             }
 
             $result[] = ParameterDTO::parseValueIncludingUnit(name: $attribute['paramNameEn'], value: $attribute['paramValueEn'], group: null);

--- a/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
@@ -270,8 +270,11 @@ class LCSCProvider implements InfoProviderInterface
 
         foreach ($attributes as $attribute) {
 
+            //Skip this attribute if it's empty
+            if (in_array(trim($attribute['paramValueEn']), array('', '-'))) {
+              continue;
             //If the attribute contains a tilde we assume it is a range
-            if (str_contains($attribute['paramValueEn'], '~')) {
+            } elseif (str_contains($attribute['paramValueEn'], '~')) {
                 $parts = explode('~', $attribute['paramValueEn']);
                 if (count($parts) === 2) {
                     //Try to extract number and unit from value (allow leading +)


### PR DESCRIPTION
This is a minor tweak for #526, specifically for https://github.com/Part-DB/Part-DB-server/issues/526#issuecomment-1960444586

I noticed, that (LCSC) attributes of ranges with negative values were still saved as text. That was due to the minus character, that was missing from the regular expression in splitIntoValueAndUnit().