### PR TITLE
Process placeholder macros in Twig mode

### DIFF
--- a/src/Services/LabelSystem/LabelHTMLGenerator.php
+++ b/src/Services/LabelSystem/LabelHTMLGenerator.php
@@ -87,8 +87,10 @@ final class LabelHTMLGenerator
                     throw new TwigModeException($exception);
                 }
             } else {
-                $lines = $this->replacer->replace($options->getLines(), $element);
+                $lines = $options->getLines();
             }
+
+            $lines = $this->replacer->replace($lines, $element);
 
             $twig_elements[] = [
                 'element' => $element,


### PR DESCRIPTION
This is a quick hack to implement solution idea in #546

The LabelTextReplacer will run in Twig process mode as well, after Twig rendered the template. That way you can use existing Placeholder templates and just have to insert Twig statements where you need them, rather than having to convert the entire template before anything starts working again.