### PR TITLE
Avoid throwing an exception if Content-Disposition header doesn't exist or contains illegal things

### DIFF
--- a/src/Services/Attachments/AttachmentSubmitHandler.php
+++ b/src/Services/Attachments/AttachmentSubmitHandler.php
@@ -370,8 +370,10 @@ class AttachmentSubmitHandler
             //If a content disposition header was set try to extract the filename out of it
             if (isset($headers['content-disposition'])) {
                 $tmp = [];
-                if (preg_match('/[^;\\n=]*=([\'\"])*(.*)(?(1)\1|)/', $headers['content-disposition'][0], $tmp))
+                //Only use the filename if the regex matches properly
+                if (preg_match('/[^;\\n=]*=([\'\"])*(.*)(?(1)\1|)/', $headers['content-disposition'][0], $tmp)) {
                     $filename = $tmp[2];
+                }
             }
 
             //If we don't know filename yet, try to determine it out of url

--- a/src/Services/Attachments/AttachmentSubmitHandler.php
+++ b/src/Services/Attachments/AttachmentSubmitHandler.php
@@ -370,8 +370,8 @@ class AttachmentSubmitHandler
             //If a content disposition header was set try to extract the filename out of it
             if (isset($headers['content-disposition'])) {
                 $tmp = [];
-                preg_match('/[^;\\n=]*=([\'\"])*(.*)(?(1)\1|)/', $headers['content-disposition'][0], $tmp);
-                $filename = $tmp[2];
+                if (preg_match('/[^;\\n=]*=([\'\"])*(.*)(?(1)\1|)/', $headers['content-disposition'][0], $tmp))
+                    $filename = $tmp[2];
             }
 
             //If we don't know filename yet, try to determine it out of url


### PR DESCRIPTION
The other day I was creating a bunch of parts by pulling data from DigiKeys API, but for some reason Akamai (their CDN) blocks my IP, so I can't download any images or datasheets.

Excerpt from var/log/prod.log
```
{
    "message": "Uncaught PHP Exception TypeError: \"pathinfo(): Argument #1 ($path) must be of type string, null given\" at AttachmentSubmitHandler.php line 386",
    "context": {
        "exception": {
            "class": "TypeError",
            "message": "pathinfo(): Argument #1 ($path) must be of type string, null given",
            "code": 0,
            "file": "/usr/local/www/partdb/src/Services/Attachments/AttachmentSubmitHandler.php:386"
        }
    },
    "level": 500,
    "level_name": "CRITICAL",
    "channel": "request",
    "datetime": "2024-03-09T23:47:21.839981+01:00",
    "extra": {
        "token": {
            "authenticated": true,
            "roles": [
                "ROLE_USER"
            ],
            "user_identifier": "***"
        },
        "url": "/en/part/329/from_info_provider/digikey/SAM1092-20-ND/update",
        "ip": "37.201.c.d",
        "http_method": "POST",
        "server": "partdb.example.org",
        "referrer": "https://partdb.example.org/en/part/329/from_info_provider/digikey/SAM1092-20-ND/update"
    }
}
```

I tracked it down to Akamais error message (validly) not containing a Content-Disposition heeader, which Part-DB doesn't expect. I patched a small "if" statement into the code, which worked beautifully.
I can not download any file of course still, but at least the part is being created with external attachments which I can then take care of later.