### PR TITLE
LCSC: Follow first 'pdfUrl' link to get real datasheet URL

### DIFF
--- a/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
@@ -99,7 +99,6 @@ class LCSCProvider implements InfoProviderInterface
         if (!empty($url) && preg_match("/^https:\/\/(datasheet\.lcsc\.com|www\.lcsc\.com\/datasheet)\/.*(C\d+)\.pdf$/", $url, $matches) > 0) {
           $response = $this->lcscClient->request('GET', $url, [
               'headers' => [
-                  'User-agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15',
                   'Referer' => 'https://www.lcsc.com/product-detail/_' . $matches[2] . '.html'
               ],
           ]);

--- a/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
@@ -103,6 +103,8 @@ class LCSCProvider implements InfoProviderInterface
               ],
           ]);
           if (preg_match('/(pdfUrl): ?("[^"]+wmsc\.lcsc\.com[^"]+\.pdf")/', $response->getContent(), $matches) > 0) {
+            //HACKY: The URL string contains escaped characters like \u002F, etc. To decode it, the JSON decoding is reused
+            //See https://github.com/Part-DB/Part-DB-server/pull/582#issuecomment-2033125934
             $jsonObj = json_decode('{"' . $matches[1] . '": ' . $matches[2] . '}');
             $url = $jsonObj->pdfUrl;
           }

--- a/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
@@ -91,7 +91,7 @@ class LCSCProvider implements InfoProviderInterface
     }
 
     /**
-     * @param  string  url
+     * @param  string  $url
      * @return String
      */
     private function getRealDatasheetUrl(?string $url): string

--- a/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
@@ -91,7 +91,7 @@ class LCSCProvider implements InfoProviderInterface
     }
 
     /**
-     * @param  string  $pdfURL
+     * @param  string  url
      * @return String
      */
     private function getRealDatasheetUrl(?string $url): string


### PR DESCRIPTION
LCSC changed their website. The "pdfUrl" key does not contain the link to the actual PDF anymore. It now links to a website that shows the datasheet side by side with an "add to cart" form.
That does not work at all if it's downloaded by Part-DB so I patched the LCSC provider, to open the first link and extract the actual PDF URL from it. I was getting some strange errors while testing, so I included a Referrer and User-Agent header. It's been working 100% for me since then.

PS:
Unfortunately I could not find an API method to get the real datasheet URL, so I resorted to scraping the HTML website. If anyone can get their hands on an LCSC API description (official or not), I'll be more than happy to update the code.