### PR TITLE
Improve parameter parsing

### DIFF
--- a/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
+++ b/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
@@ -72,9 +72,8 @@ class ParameterDTO
                 //Try to extract number and unit from value (allow leading +)
                 if (empty($unit)) {
                     [$number, $unit] = self::splitIntoValueAndUnit(ltrim($parts[0], " +")) ?? [$parts[0], null];
-                    $unit2 = null;
                 } else {
-                    $unit2 = $unit;
+                    $number = $parts[0];
                 }
                 // If the second part has some extra info, we'll save that into value_text
                 if (!empty($unit) && preg_match('/^(.+' . preg_quote($unit) . ')\s*(.+)$/', $parts[1], $matches) > 0) {
@@ -83,9 +82,7 @@ class ParameterDTO
                 } else {
                     $value_text2 = null;
                 }
-                if (empty($unit2)) {
-                    [$number2, $unit2] = self::splitIntoValueAndUnit(ltrim($parts[1], " +")) ?? [$parts[1], null];
-                }
+                [$number2, $unit2] = self::splitIntoValueAndUnit(ltrim($parts[1], " +")) ?? [$parts[1], $unit];
 
                 //If both parts have the same unit and both values are numerical, we assume it is a range
                 if ($unit === $unit2 && is_numeric($number) && is_numeric($number2)) {

--- a/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
+++ b/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
@@ -70,7 +70,12 @@ class ParameterDTO
             $parts = preg_split('/\s*(\.{3}|~)\s*/', $value);
             if (count($parts) === 2) {
                 //Try to extract number and unit from value (allow leading +)
-                [$number, $unit] = self::splitIntoValueAndUnit(ltrim($parts[0], " +")) ?? [$parts[0], null];
+                if (empty($unit)) {
+                    [$number, $unit] = self::splitIntoValueAndUnit(ltrim($parts[0], " +")) ?? [$parts[0], null];
+                    $unit2 = null;
+                } else {
+                    $unit2 = $unit;
+                }
                 // If the second part has some extra info, we'll save that into value_text
                 if (!empty($unit) && preg_match('/^(.+' . preg_quote($unit) . ')\s*(.+)$/', $parts[1], $matches) > 0) {
                     $parts[1] = $matches[1];
@@ -78,18 +83,20 @@ class ParameterDTO
                 } else {
                     $value_text2 = null;
                 }
-                [$number2, $unit2] = self::splitIntoValueAndUnit(ltrim($parts[1], " +")) ?? [$parts[1], null];
+                if (empty($unit2)) {
+                    [$number2, $unit2] = self::splitIntoValueAndUnit(ltrim($parts[1], " +")) ?? [$parts[1], null];
+                }
 
                 //If both parts have the same unit and both values are numerical, we assume it is a range
                 if ($unit === $unit2 && is_numeric($number) && is_numeric($number2)) {
-                    return new self(name: $name, value_min: (float) $number, value_max: (float) $number2, value_text: $value_text2, unit: $unit, group: null);
+                    return new self(name: $name, value_min: (float) $number, value_max: (float) $number2, value_text: $value_text2, unit: $unit, symbol: $symbol, group: $group);
                 }
             }
         //If it's a plus/minus value, we'll also treat it as a range
         } elseif (str_starts_with($value, '±')) {
           [$number, $unit] = self::splitIntoValueAndUnit(ltrim($value, " ±")) ?? [$value, null];
           if (is_numeric($number)) {
-            return new self(name: $name, value_min: -abs((float) $number), value_max: abs((float) $number), unit: $unit, group: null);
+            return new self(name: $name, value_min: -abs((float) $number), value_max: abs((float) $number), unit: $unit, symbol: $symbol, group: $group);
           }
         }
 

--- a/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
+++ b/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
@@ -137,7 +137,7 @@ class ParameterDTO
      */
     public static function splitIntoValueAndUnit(string $value): ?array
     {
-       if (preg_match('/^(?<value>-?[0-9\.]+)\s*(?<unit>[%Ω°℃a-z_\/]+\s?\w{0,4})$/iu', $value, $matches)) {
+       if (preg_match('/^(?<value>-?[0-9\.]+)\s*(?<unit>[%Ωµ°℃a-z_\/]+\s?\w{0,4})$/iu', $value, $matches)) {
            $value = $matches['value'];
            $unit = $matches['unit'];
 

--- a/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
+++ b/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
@@ -45,6 +45,9 @@ class ParameterDTO
     /**
      * This function tries to decide on the value, if it is a numerical value (which is then stored in one of the value_*) fields) or a text value (which is stored in value_text).
      * It is possible to give ranges like 1...2 (or 1~2) here, which will be parsed as value_min: 1.0, value_max: 2.0.
+     *
+     * For certain expressions (like ranges) the unit is automatically extracted from the value, if no unit is given
+     * @TODO Rework that, so that the difference between parseValueField and parseValueIncludingUnit is clearer or merge them
      * @param  string  $name
      * @param  string|float  $value
      * @param  string|null  $unit

--- a/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
+++ b/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
@@ -75,6 +75,8 @@ class ParameterDTO
                 if (!empty($unit) && preg_match('/^(.+' . preg_quote($unit) . ')\s*(.+)$/', $parts[1], $matches) > 0) {
                     $parts[1] = $matches[1];
                     $value_text2 = $matches[2];
+                } else {
+                    $value_text2 = null;
                 }
                 [$number2, $unit2] = self::splitIntoValueAndUnit(ltrim($parts[1], " +")) ?? [$parts[1], null];
 

--- a/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
+++ b/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
@@ -65,7 +65,7 @@ class ParameterDTO
             return new self($name, value_typ: (float) $value, value_text: $value_text, unit: $unit, symbol: $symbol, group: $group);
         }
 
-        //If the attribute contains a tilde we assume it is a range
+        //If the attribute contains "..." or a tilde we assume it is a range
         if (preg_match('/(\.{3}|~)/', $value) === 1) {
             $parts = preg_split('/\s*(\.{3}|~)\s*/', $value);
             if (count($parts) === 2) {
@@ -84,7 +84,7 @@ class ParameterDTO
                 }
                 [$number2, $unit2] = self::splitIntoValueAndUnit(ltrim($parts[1], " +")) ?? [$parts[1], $unit];
 
-                //If both parts have the same unit and both values are numerical, we assume it is a range
+                //If both parts have the same unit and both values are numerical, we'll save it as range
                 if ($unit === $unit2 && is_numeric($number) && is_numeric($number2)) {
                     return new self(name: $name, value_min: (float) $number, value_max: (float) $number2, value_text: $value_text2, unit: $unit, symbol: $symbol, group: $group);
                 }

--- a/src/Services/InfoProviderSystem/Providers/DigikeyProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/DigikeyProvider.php
@@ -210,6 +210,10 @@ class DigikeyProvider implements InfoProviderInterface
                 $footprint_name = $parameter['Value'];
             }
 
+            if (in_array(trim($parameter['Value']), array('', '-'), true)) {
+                continue;
+            }
+
             $results[] = ParameterDTO::parseValueIncludingUnit($parameter['Parameter'], $parameter['Value']);
         }
 

--- a/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
@@ -299,27 +299,6 @@ class LCSCProvider implements InfoProviderInterface
             //Skip this attribute if it's empty
             if (in_array(trim($attribute['paramValueEn']), array('', '-'), true)) {
               continue;
-            //If the attribute contains a tilde we assume it is a range
-            } elseif (str_contains($attribute['paramValueEn'], '~')) {
-                $parts = explode('~', $attribute['paramValueEn']);
-                if (count($parts) === 2) {
-                    //Try to extract number and unit from value (allow leading +)
-                    [$number, $unit] = ParameterDTO::splitIntoValueAndUnit(ltrim($parts[0], " +")) ?? [$parts[0], null];
-                    [$number2, $unit2] = ParameterDTO::splitIntoValueAndUnit(ltrim($parts[1], " +")) ?? [$parts[1], null];
-
-                    //If both parts have the same unit and both values are numerical, we assume it is a range
-                    if ($unit === $unit2 && is_numeric($number) && is_numeric($number2)) {
-                        $result[] = new ParameterDTO(name: $attribute['paramNameEn'], value_min: (float) $number, value_max: (float) $number2, unit: $unit, group: null);
-                        continue;
-                    }
-                }
-            //If it's a plus/minus value, we'll also it like a range
-            } elseif (str_starts_with($attribute['paramValueEn'], '±')) {
-              [$number, $unit] = ParameterDTO::splitIntoValueAndUnit(ltrim($attribute['paramValueEn'], " ±")) ?? [$attribute['paramValueEn'], null];
-              if (is_numeric($number)) {
-                $result[] = new ParameterDTO(name: $attribute['paramNameEn'], value_min: -abs((float) $number), value_max: abs((float) $number), unit: $unit, group: null);
-                continue;
-              }
             }
 
             $result[] = ParameterDTO::parseValueIncludingUnit(name: $attribute['paramNameEn'], value: $attribute['paramValueEn'], group: null);

--- a/tests/Services/InfoProviderSystem/DTOs/ParameterDTOTest.php
+++ b/tests/Services/InfoProviderSystem/DTOs/ParameterDTOTest.php
@@ -67,6 +67,56 @@ class ParameterDTOTest extends TestCase
             'm',
             'test'
         ];
+
+        //Test ranges with tilde
+        yield [
+            new ParameterDTO('test', value_min: -1.0, value_max: 2.0, unit: 'kg', symbol: 'm', group: 'test'),
+            'test',
+            '-1.0~+2.0', //Leading signs are parsed correctly
+            'kg',
+            'm',
+            'test'
+        ];
+
+        //Test ranges with comment
+        yield [
+            new ParameterDTO('test', value_text: "Test", value_min: -1.0, value_max: 2.0, unit: 'kg', symbol: 'm',
+                group: 'test'),
+            'test',
+            '-1.0~+2.0 kg Test', //Leading signs are parsed correctly
+            'kg',
+            'm',
+            'test'
+        ];
+
+        //Test @comment
+        yield [
+            new ParameterDTO('test', value_text: "@comment", value_typ: 1.0, unit: 'kg', symbol: 'm', group: 'test'),
+            'test',
+            '1.0@comment',
+            'kg',
+            'm',
+            'test'
+        ];
+
+        //Test plus minus range (without unit)
+        yield [
+            new ParameterDTO('test', value_min: -1.0, value_max: +1.0, unit: 'kg', symbol: 'm', group: 'test'),
+            'test',
+            '±1.0',
+            'kg',
+            'm',
+            'test'
+        ];
+
+        yield [ //And with unit
+            new ParameterDTO('test', value_min: -1.0, value_max: +1.0, unit: 'kg', symbol: 'm', group: 'test'),
+            'test',
+            '±1.0kg',
+            'kg',
+            'm',
+            'test'
+        ];
     }
 
     public function parseValueIncludingUnitDataProvider(): \Generator
@@ -175,6 +225,7 @@ class ParameterDTOTest extends TestCase
         $this->assertEquals(["70", "℃"], ParameterDTO::splitIntoValueAndUnit("70℃"));
 
         $this->assertEquals(["-5.0", "kg"], ParameterDTO::splitIntoValueAndUnit("-5.0 kg"));
+        $this->assertEquals(["-5.0", "µg"], ParameterDTO::splitIntoValueAndUnit("-5.0 µg"));
 
         $this->assertNull(ParameterDTO::splitIntoValueAndUnit('kg'));
         $this->assertNull(ParameterDTO::splitIntoValueAndUnit('Test'));

--- a/tests/Services/InfoProviderSystem/DTOs/ParameterDTOTest.php
+++ b/tests/Services/InfoProviderSystem/DTOs/ParameterDTOTest.php
@@ -192,6 +192,33 @@ class ParameterDTOTest extends TestCase
             'm',
             'test'
         ];
+
+        //Test ranges with tilde
+        yield [
+            new ParameterDTO('test', value_min: -1.0, value_max: 2.0, unit: 'kg', symbol: 'm', group: 'test'),
+            'test',
+            '-1.0kg~+2.0kg', //Leading signs are parsed correctly
+            'm',
+            'test'
+        ];
+
+        //Test @comment
+        yield [
+            new ParameterDTO('test', value_text: "@comment", value_typ: 1.0, unit: 'kg', symbol: 'm', group: 'test'),
+            'test',
+            '1.0 kg@comment',
+            'm',
+            'test'
+        ];
+
+        //Test plus minus range (without unit)
+        yield [
+            new ParameterDTO('test', value_min: -1.0, value_max: +1.0, unit: 'kg', symbol: 'm', group: 'test'),
+            'test',
+            '±1.0 kg',
+            'm',
+            'test'
+        ];
     }
 
     /**


### PR DESCRIPTION
This will improve the following cases (example values):

`-40°C ~ 125°C`

This worked for LCSC only. Other providers needed "..." as range indicator and values with units could not be processed at all.

`-40°C ~ 125°C @Tj`

Extra info at the end stopped the range detection altogether, because the two "units" would not match. Extra info will now be saved to the "Text" column, making the units match and thus allowing the actual values to be saved as range.

`22 µH`

"µ" was missing in the unit detection regex