### PR TITLE
Update LCSC API URL

### DIFF
--- a/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
@@ -35,7 +35,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 class LCSCProvider implements InfoProviderInterface
 {
 
-    private const ENDPOINT_URL = 'https://wmsc.lcsc.com/wmsc';
+    private const ENDPOINT_URL = 'https://wmsc.lcsc.com/ftps/wm';
 
     public const DISTRIBUTOR_NAME = 'LCSC';
 


### PR DESCRIPTION
This directly fixes #611 

It would still be nice to be able to customize the URL directly using an environment variable, something like `PROVIDER_LCSC_ENDPOINT_URL`.