### PR TITLE
Update LCSCProvider field for real datasheet URL

### DIFF
--- a/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
@@ -102,11 +102,11 @@ class LCSCProvider implements InfoProviderInterface
                   'Referer' => 'https://www.lcsc.com/product-detail/_' . $matches[2] . '.html'
               ],
           ]);
-          if (preg_match('/(pdfUrl): ?("[^"]+wmsc\.lcsc\.com[^"]+\.pdf")/', $response->getContent(), $matches) > 0) {
+          if (preg_match('/(previewPdfUrl): ?("[^"]+wmsc\.lcsc\.com[^"]+\.pdf")/', $response->getContent(), $matches) > 0) {
             //HACKY: The URL string contains escaped characters like \u002F, etc. To decode it, the JSON decoding is reused
             //See https://github.com/Part-DB/Part-DB-server/pull/582#issuecomment-2033125934
             $jsonObj = json_decode('{"' . $matches[1] . '": ' . $matches[2] . '}');
-            $url = $jsonObj->pdfUrl;
+            $url = $jsonObj->previewPdfUrl;
           }
         }
         return $url;


### PR DESCRIPTION
I noticed, that LCSC changed the field containing the URL to the real datasheet.

I updated the LCSCProvider method accordingly.