### PR TITLE
feat(docker): Refactor Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,8 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 # Install composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
-ENV APACHE_CONFDIR /etc/apache2
-ENV APACHE_ENVVARS $APACHE_CONFDIR/envvars
+ENV APACHE_CONFDIR=/etc/apache2
+ENV APACHE_ENVVARS=$APACHE_CONFDIR/envvars
 
 # Configure apache 2 (taken from https://github.com/docker-library/php/blob/master/8.2/bullseye/apache/Dockerfile)
 # generically convert lines like

--- a/Dockerfile
+++ b/Dockerfile
@@ -136,8 +136,8 @@ ARG PHP_VERSION
 
 # Set working dir
 WORKDIR /var/www/html
-COPY --chown=www-data:www-data . .
 COPY --from=apache-config / /
+COPY --chown=www-data:www-data . .
 
 # Setup apache2
 RUN a2dissite 000-default.conf && \

--- a/Dockerfile-frankenphp
+++ b/Dockerfile-frankenphp
@@ -1,11 +1,25 @@
 FROM dunglas/frankenphp:1-php8.3 AS frankenphp_upstream
 
-RUN apt-get update && apt-get -y install curl zip mariadb-client postgresql-client file acl git gettext ca-certificates gnupg \
+RUN apt-get update && apt-get -y install \
+      curl \
+      ca-certificates \
+      mariadb-client \
+      postgresql-client \
+      file \
+      acl \
+      git \
+      gettext \
+      gnupg \
+      zip \
     && apt-get -y autoremove && apt-get clean autoclean && rm -rf /var/lib/apt/lists/*;
 
-# Create workdir and set permissions if directory does not exists
-RUN mkdir -p /app
-WORKDIR /app
+# Install node and yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get update && apt-get install -y \
+      nodejs yarn \
+    && apt-get -y autoremove && apt-get clean autoclean && rm -rf /var/lib/apt/lists/*
 
 # Install PHP
 RUN set -eux; \
@@ -33,14 +47,12 @@ ENV FRANKENPHP_CONFIG="import worker.Caddyfile"
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
-# Install node and yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - && apt-get update && apt-get install -y nodejs yarn && apt-get -y autoremove && apt-get clean autoclean && rm -rf /var/lib/apt/lists/*
-
 # Install composer
 ENV COMPOSER_ALLOW_SUPERUSER=1
 #COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+# Create workdir and set permissions if directory does not exists
+WORKDIR /app
 
 # prevent the reinstallation of vendors at every changes in the source code
 COPY --link composer.* symfony.* ./
@@ -58,7 +70,10 @@ RUN set -eux; \
 	composer run-script --no-dev post-install-cmd; \
 	chmod +x bin/console; sync;
 
-RUN yarn install --network-timeout 600000 && yarn build && yarn cache clean && rm -rf node_modules/
+RUN yarn install --network-timeout 600000 && \
+    yarn build && \
+    yarn cache clean && \
+    rm -rf node_modules/
 
 # Use docker env to output logs to stdout
 ENV APP_ENV=docker


### PR DESCRIPTION
- Reduce build layers from 23 to 12
- Add **ARG** `PHP_VERSION` to allow usage of different php versions (defaults to `8.1`)
- Reorder layers to allow common content to be reusable (layers) between different builds

Ideally `composer` can be in a separate RUN way, so if dependencies do not change, it can keep the same content from other builds, but I'm unable to setup this at the moment.
