### PR TITLE
Responsive tweaks

### DIFF
--- a/config/packages/datatables.yaml
+++ b/config/packages/datatables.yaml
@@ -10,13 +10,12 @@ datatables:
     options:
         lengthMenu : [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]]
         pageLength: '%partdb.table.default_page_size%'   # Set to -1 to disable pagination (i.e. show all rows) by default
-        #dom: "<'row' <'col-sm-12' tr>><'row' <'col-sm-6'l><'col-sm-6 text-right'pif>>"
-        dom: "  <'row'<'col mb-2 input-group' B l> <'col mb-2' <'pull-end' p>>>
-                        <'card'
-                            rt
-                            <'card-footer card-footer-table text-muted' i >
-                        >
-                        <'row'<'col mt-2 input-group' B l> <'col mt-2' <'pull-right' p>>>"
+        dom: "  <'row' <'col mb-2 input-group flex-nowrap' B l > <'col-auto mb-2' < p >>>
+                    <'card'
+                        rt
+                        <'card-footer card-footer-table text-muted' i >
+                    >
+                <'row' <'col mt-2 input-group flex-nowrap' B l > <'col-auto mt-2' < p >>>"
         pagingType: 'simple_numbers'
         searching: true
         stateSave: true

--- a/templates/parts/info/_main_infos.html.twig
+++ b/templates/parts/info/_main_infos.html.twig
@@ -1,96 +1,130 @@
 {% import "helper.twig" as helper %}
 
-<div class="row">
-    <div class="col-md-3 col-lg-4 col-3 mt-auto mb-auto">
-        {% include "parts/info/_picture.html.twig" %}
-    </div>
-    <div class="col-md-9 col-lg-8 col-7">
-        <h5 class="text-muted pt-2" title="{% trans %}manufacturer.label{% endtrans %}">
-            {% if part.manufacturer %}
-                {% if part.manufacturer.id is not null %}
-                    <a href="{{ entity_url(part.manufacturer, 'list_parts') }}">{{ part.manufacturer.name}}</a>
+{% if part.manufacturer or part.manufacturerProductUrl or part.manufacturerProductNumber %}
+<h5 class="text-muted pt-2" title="{% trans %}manufacturer.label{% endtrans %}">
+    {% if part.manufacturer %}
+        {% if part.manufacturer.id is not null %}
+            <a href="{{ entity_url(part.manufacturer, 'list_parts') }}">{{ part.manufacturer.name}}</a>
+        {% else %}
+            {{ part.manufacturer.name }}
+        {% endif %}
+    {% endif %}
+    {% if part.manufacturerProductUrl %}
+        <small>
+            <a class="link-external" href="{{ part.manufacturerProductUrl }}" rel="noopener" target="_blank">
+                {% if part.manufacturerProductNumber is not empty %}
+                    {{ part.manufacturerProductNumber }}
                 {% else %}
-                    {{ part.manufacturer.name }}
+                    <i>{{ part.name }}</i>
                 {% endif %}
-            {% endif %}
-            {% if part.manufacturerProductUrl %}
-                <small>
-                    <a class="link-external" href="{{ part.manufacturerProductUrl }}" rel="noopener" target="_blank">
-                        {% if part.manufacturerProductNumber is not empty %}
-                            {{ part.manufacturerProductNumber }}
-                        {% else %}
-                            <i>{{ part.name }}</i>
-                        {% endif %}
-                    </a>
-                </small>
-            {% else %}
-                <small>{{ part.manufacturerProductNumber }}</small>
-            {% endif %}
-        </h5>
-        <h3 class="w-fit" title="{% trans %}name.label{% endtrans %}">{{ part.name }}
-            {# You need edit permission to use the edit button #}
-            {% if timeTravel is not null %}
-                <a href="{{ entity_url(part, 'info') }}"><i title="{% trans %}part.back_to_info{% endtrans %}" class="fas fa-fw fa-arrow-circle-left"></i></a>
-            {% elseif is_granted('edit', part) %}
-                <a href="{{ entity_url(part, 'edit') }}"><i class="fas fa-fw fa-sm fa-edit"></i></a>
-            {% endif %}
-        </h3>
-        <h6 class="text-muted w-fit" title="{% trans %}description.label{% endtrans %}"><span>{{ part.description|format_markdown(true) }}</span></h6>
-        <h6 class="">
-            <i class="fas fa-tag fa-fw" title="{% trans %}category.label{% endtrans %}"></i>
-            <span class="text-muted">{{ helper.structural_entity_link(part.category) }}</span>
-        </h6>
-        <h6><i class="fas fa-shapes fa-fw"></i>
-            <span class="{% if part.notEnoughInstock and not part.amountUnknown %}text-danger font-weight-bold{% else %}text-muted{% endif %}">
-                {% if not part.amountUnknown %}
-                    {# For known instock we can just show the label as normal #}
-                    <span title="{% trans %}instock.label{% endtrans %}">{{ part.amountSum | format_amount(part.partUnit) }}</span>
-                {% else %}
-                    {% if part.amountSum == 0.0 %}
-                        <b title="{% trans %}part_lots.instock_unknown{% endtrans %}">?</b>
-                    {% else %}
-                        <span title="{% trans %}part_lots.instock_unknown{% endtrans %}">≥{{ part.amountSum | format_amount(part.partUnit) }}</span>
-                    {% endif %}
-                {% endif %}
-                {% if part.expiredAmountSum > 0 %}
-                    <span title="{% trans %}part_lots.is_expired{% endtrans %}" class="text-muted">(+{{ part.expiredAmountSum }})</span>
-                {% endif %}
-                /
-                <span title="{% trans %}mininstock.label{% endtrans %}">{{ part.minAmount | format_amount(part.partUnit) }}</span>
-            </span>
-            {% if part.notEnoughInstock %}
-                <span class="badge badge-warning bg-warning rounded-pill"><i class="fa-solid fa-less-than-equal"></i>&nbsp;{% trans %}part.info.amount.less_than_desired{% endtrans %}</span>
-            {% endif %}
-        </h6>
-        <h6 class="">
-            <i class="fas fa-microchip fa-fw" title="{% trans %}footprint.label{% endtrans %}"></i>
-            <span class="text-muted">{{ helper.structural_entity_link(part.footprint) }}</span>
-        </h6>
+            </a>
+        </small>
+    {% elseif part.manufacturerProductNumber %}
+        <small>{{ part.manufacturerProductNumber }}</small>
+    {% endif %}
+</h5>
+{% endif %}
 
-        {% set min_order_amount = pricedetail_helper.minOrderAmount(part) %}
-        {% set max_order_amount = pricedetail_helper.maxDiscountAmount(part) %}
-        {% set max_order_price = pricedetail_helper.calculateAvgPrice(part, max_order_amount, app.user.currency ?? null) %}
-        {% set min_order_price = pricedetail_helper.calculateAvgPrice(part, min_order_amount, app.user.currency ?? null ) %}
-        {% if max_order_price is not null %}
-            <h6>
+<h3 class="w-fit" title="{% trans %}name.label{% endtrans %}">
+    {{ part.name }}
+    {# You need edit permission to use the edit button #}
+    {% if timeTravel is not null %}
+        <a href="{{ entity_url(part, 'info') }}"><i title="{% trans %}part.back_to_info{% endtrans %}" class="fas fa-fw fa-arrow-circle-left"></i></a>
+    {% elseif is_granted('edit', part) %}
+        <a href="{{ entity_url(part, 'edit') }}"><i class="fas fa-fw fa-sm fa-edit"></i></a>
+    {% endif %}
+</h3>
+
+<dl>
+    <div>
+        <dt>
+            <span class="visually-hidden">{% trans %}description.label{% endtrans %}</span>
+        </dt>
+        <dd class="d-inline">
+            <span class="text-muted w-fit" title="{% trans %}description.label{% endtrans %}">{{ part.description|format_markdown(true) }}</span>
+        </dd>
+    </div>
+
+    <div>
+        <dt class="d-inline-block">
+            <span class="visually-hidden">{% trans %}category.label{% endtrans %}</span>
+            <i class="fas fa-tag fa-fw" title="{% trans %}category.label{% endtrans %}"></i>
+        </dt>
+        <dd class="d-inline">
+            <span class="text-muted">{{ helper.structural_entity_link(part.category) }}</span>
+        </dd>
+    </div>
+
+    <div>
+        <dt class="d-inline-block">
+            <span class="visually-hidden">{% trans %}part.part_lots.label{% endtrans %}</span>
+            <i class="fas fa-shapes fa-fw"></i>
+        </dt>
+        <dd class="d-inline">
+            <span class="{% if part.notEnoughInstock and not part.amountUnknown %}text-danger font-weight-bold{% else %}text-muted{% endif %}">
+            {% if not part.amountUnknown %}
+                {# For known instock we can just show the label as normal #}
+                <span title="{% trans %}instock.label{% endtrans %}">{{ part.amountSum | format_amount(part.partUnit) }}</span>
+            {% else %}
+                {% if part.amountSum == 0.0 %}
+                    <b title="{% trans %}part_lots.instock_unknown{% endtrans %}">?</b>
+                {% else %}
+                    <span title="{% trans %}part_lots.instock_unknown{% endtrans %}">≥{{ part.amountSum | format_amount(part.partUnit) }}</span>
+                {% endif %}
+            {% endif %}
+            {% if part.expiredAmountSum > 0 %}
+                <span title="{% trans %}part_lots.is_expired{% endtrans %}" class="text-muted">(+{{ part.expiredAmountSum }})</span>
+            {% endif %}
+            /
+            <span title="{% trans %}mininstock.label{% endtrans %}">{{ part.minAmount | format_amount(part.partUnit) }}</span>
+        </span>
+        {% if part.notEnoughInstock %}
+            <span class="badge badge-warning bg-warning rounded-pill"><i class="fa-solid fa-less-than-equal"></i>&nbsp;{% trans %}part.info.amount.less_than_desired{% endtrans %}</span>
+        {% endif %}
+        </dd>
+    </div>
+
+    <div>
+        <dt class="d-inline-block">
+            <span class="visually-hidden">{% trans %}footprint.label{% endtrans %}</span>
+            <i class="fas fa-microchip fa-fw" title="{% trans %}footprint.label{% endtrans %}"></i>
+        </dt>
+        <dd class="d-inline">
+            <span class="text-muted">{{ helper.structural_entity_link(part.footprint) }}</span>
+        </dd>
+    </div>
+
+    {% set min_order_amount = pricedetail_helper.minOrderAmount(part) %}
+    {% set max_order_amount = pricedetail_helper.maxDiscountAmount(part) %}
+    {% set max_order_price = pricedetail_helper.calculateAvgPrice(part, max_order_amount, app.user.currency ?? null) %}
+    {% set min_order_price = pricedetail_helper.calculateAvgPrice(part, min_order_amount, app.user.currency ?? null ) %}
+    {% if max_order_price is not null %}
+        <div>
+            <dt class="d-inline-block">
                 <i class="fas fa-money-bill-alt fa-fw"></i>
+            </dt>
+            <dd class="d-inline">
                 <span class="text-muted">
                     <span title="{% trans %}part.avg_price.label{% endtrans %} {{ max_order_amount | format_amount(part.partUnit) }}">{{ max_order_price | format_money(app.user.currency ?? null) }}</span>
                     {% if min_order_price is not null and min_order_amount < max_order_amount %}
                         <span> - </span>
                         <span title="{% trans %}part.avg_price.label{% endtrans %} {{ min_order_amount | format_amount(part.partUnit) }}">{% if max_order_price is not null %}{{ min_order_price | format_money(app.user.currency ?? null) }}{% else %}???{% endif %}</span>
                     {% endif %}
-            </span>
-            </h6>
-        {% endif %}
-        {#
-        {% if part.comment != "" %}
-            <h6 title="{% trans %}comment.label{% endtrans %}">
-                <i class="fas fa-comment-alt fa-fw"></i>
-                <div class="d-inline-flex">
-                    <span class="text-muted">{{ part.comment|nl2br }}</span>
-                </div>
-            </h6>
-        {% endif %} #}
-    </div>
-</div>
+                </span>
+            </dd>
+        </div>
+    {% endif %}
+
+    {# {% if part.comment != "" %}
+        <div>
+            <dt class="d-inline-block">
+                <span class="visually-hidden">{% trans %}comment.label{% endtrans %}</span>
+                <i class="fas fa-comment-alt fa-fw" title="{% trans %}comment.label{% endtrans %}"></i>
+            </dt>
+            <dd class="d-inline">
+                <span class="text-muted">>{{ part.comment|nl2br }}</span>
+            </dd>
+        </div>
+    {% endif %} #}
+</dl>
+

--- a/templates/parts/info/show_part_info.html.twig
+++ b/templates/parts/info/show_part_info.html.twig
@@ -15,173 +15,176 @@
 {% endblock %}
 
 {% block card_title %}
-    <i class="fa {{ part.favorite ? 'fa-star' : 'fa-info-circle'}} fa-fw" aria-hidden="true"></i>
-    {% trans %}part.info.title{% endtrans %} <b>"{{ part.name }}"</b>
-    {% if timeTravel != null %}
-        <i>({{ timeTravel | format_datetime('short') }})</i>
-    {% endif %}
-    {% if part.projectBuildPart %}
-        (<i>{{ entity_type_label(part.builtProject) }}</i>: <a class="text-white" href="{{ entity_url(part.builtProject) }}">{{ part.builtProject.name }}</a>)
-    {% endif %}
-    <div class="float-end">
+    <span>
+        <i class="fa {{ part.favorite ? 'fa-star' : 'fa-info-circle'}} fa-fw" aria-hidden="true"></i>
+        {% trans %}part.info.title{% endtrans %} <b>"{{ part.name }}"</b>
+        {% if timeTravel != null %}
+            <i>({{ timeTravel | format_datetime('short') }})</i>
+        {% endif %}
+        {% if part.projectBuildPart %}
+            (<i>{{ entity_type_label(part.builtProject) }}</i>: <a class="text-white" href="{{ entity_url(part.builtProject) }}">{{ part.builtProject.name }}</a>)
+        {% endif %}
+    </span>
+    <span class="float-end">
         {% trans %}id.label{% endtrans %}: {{ part.id }} {% if part.ipn is not empty %}(<i>{{ part.ipn }}</i>){% endif %}
-    </div>
+    </span>
 {% endblock %}
 
 {% block card_content %}
     <div class="row">
-        <div class="col-md-9">
+        <div class="col col-md-3 mt-auto mb-auto">
+            {% include "parts/info/_picture.html.twig" %}
+        </div>
+
+        <div class="col-12 col-md-9 col-lg-6">
             {% include "parts/info/_main_infos.html.twig" %}
         </div>
 
-        <div class="col-md-3 offset-md-0 col-9 offset-3">
+        <div class="col offset-md-3 offset-lg-0">
             {% include "parts/info/_sidebar.html.twig" %}
         </div>
-
     </div>
 
     <div class="">
-        <div class="">
-            <ul class="nav nav-tabs" id="partTab" role="tablist">
+        <ul class="nav nav-tabs" id="partTab" role="tablist">
+            <li class="nav-item">
+                <a class="nav-link {% if part.partLots %}active{% endif %}" id="part_lots-tab" data-bs-toggle="tab"
+                    href="#part_lots" role="tab">
+                    <i class="fas fa-box fa-fw"></i>
+                    {% trans %}part.part_lots.label{% endtrans %}
+                    <span class="badge bg-secondary">{{ part.partLots | length }}</span>
+                </a>
+            </li>
+            {% if part.comment is not empty %}
                 <li class="nav-item">
-                    <a class="nav-link {% if part.partLots %}active{% endif %}" id="part_lots-tab" data-bs-toggle="tab"
-                       href="#part_lots" role="tab">
-                        <i class="fas fa-box fa-fw"></i>
-                        {% trans %}part.part_lots.label{% endtrans %}
-                        <span class="badge bg-secondary">{{ part.partLots | length }}</span>
+                    <a class="nav-link" id="comment-tab" data-bs-toggle="tab"
+                        href="#comment" role="tab">
+                        <i class="fas fa-sticky-note fa-fw"></i>
+                        {% trans %}comment.label{% endtrans %}
                     </a>
                 </li>
-                {% if part.comment is not empty %}
-                    <li class="nav-item">
-                        <a class="nav-link" id="comment-tab" data-bs-toggle="tab"
-                           href="#comment" role="tab">
-                            <i class="fas fa-sticky-note fa-fw"></i>
-                            {% trans %}comment.label{% endtrans %}
-                        </a>
-                    </li>
-                {% endif %}
-                {% if part.parameters is not empty or description_params is not empty or comment_params is not empty %}
-                    <li class="nav-item">
-                        <a class="nav-link" data-bs-toggle="tab" role="tab" href="#specifications">
-                            <i class="fas fa-atlas fa-fw"></i>
-                            {% trans %}part.info.specifications{% endtrans %}
-                            <span class="badge bg-secondary">{{ part.parameters | length }}</span>
-                        </a>
-                    </li>
-                {% endif %}
-                {% if part.attachments is not empty %}
-                    <li class="nav-item">
-                        <a class="nav-link" id="attachment-tab" data-bs-toggle="tab"
-                           href="#attachments" role="tab">
-                            <i class="fas fa-paperclip fa-fw"></i>
-                            {% trans %}attachment.labelp{% endtrans %}
-                            <span class="badge bg-secondary">{{ part.attachments | length }}</span>
-                        </a>
-                    </li>
-                {% endif %}
-                {% if part.orderdetails is not empty %}
-                    <li class="nav-item">
-                        <a class="nav-link" id="supplier-tab" data-bs-toggle="tab" href="#suppliers" role="tab">
-                            <i class="fas fa-shopping-cart fa-fw"></i>
-                            {% trans %}vendor.partinfo.shopping_infos{% endtrans %}
-                            <span class="badge bg-secondary">{{ part.orderdetails | length }}</span>
-                        </a>
-                    </li>
-                {% endif %}
-
-                {% if part.associatedPartsAll is not empty %}
-                    <li class="nav-item">
-                        <a class="nav-link" id="associations-tab" data-bs-toggle="tab" href="#associations" role="tab">
-                            <i class="fas fas fa-circle-nodes fa-fw fa-fw"></i>
-                            {% trans %}part.edit.tab.associations{% endtrans %}
-                            <span class="badge bg-secondary">{{ part.associatedPartsAll | length }}</span>
-                        </a>
-                    </li>
-                {% endif %}
-
-                <li class="nav-item {% if datatable is null %}not-allowed{% endif %}">
-                    <a class="nav-link {% if datatable is null %}disabled{% endif %}" id="history-tab" data-bs-toggle="tab" href="#history" role="tab">
-                        <i class="fas fa-history"></i>
-                        {% trans %}vendor.partinfo.history{% endtrans %}
-                    </a>
-                </li>
-                {% if part.projectBomEntries is not empty %}
-                    <li class="nav-item">
-                        <a class="nav-link" id="projects-tab" data-bs-toggle="tab" href="#projects" role="tab">
-                            <i class="fas fa-archive fa-fw"></i>
-                            {% trans %}project.labelp{% endtrans %}
-                            <span class="badge bg-secondary">{{ part.projectBomEntries | length }}</span>
-                        </a>
-                    </li>
-                {% endif %}
+            {% endif %}
+            {% if part.parameters is not empty or description_params is not empty or comment_params is not empty %}
                 <li class="nav-item">
-                    <a class="nav-link" id="tools-tab" data-bs-toggle="tab" href="#tools" role="tab">
-                        <i class="fas fa-tools"></i>
-                        {% trans %}tools.label{% endtrans %}
+                    <a class="nav-link" data-bs-toggle="tab" role="tab" href="#specifications">
+                        <i class="fas fa-atlas fa-fw"></i>
+                        {% trans %}part.info.specifications{% endtrans %}
+                        <span class="badge bg-secondary">{{ part.parameters | length }}</span>
                     </a>
                 </li>
+            {% endif %}
+            {% if part.attachments is not empty %}
                 <li class="nav-item">
-                    <a class="nav-link" id="extended_info-tab" data-bs-toggle="tab" href="#extended_info" role="tab">
-                        <i class="fas fa-clipboard-list"></i>
-                        {% trans %}extended_info.label{% endtrans %}
+                    <a class="nav-link" id="attachment-tab" data-bs-toggle="tab"
+                        href="#attachments" role="tab">
+                        <i class="fas fa-paperclip fa-fw"></i>
+                        {% trans %}attachment.labelp{% endtrans %}
+                        <span class="badge bg-secondary">{{ part.attachments | length }}</span>
                     </a>
                 </li>
+            {% endif %}
+            {% if part.orderdetails is not empty %}
+                <li class="nav-item">
+                    <a class="nav-link" id="supplier-tab" data-bs-toggle="tab" href="#suppliers" role="tab">
+                        <i class="fas fa-shopping-cart fa-fw"></i>
+                        {% trans %}vendor.partinfo.shopping_infos{% endtrans %}
+                        <span class="badge bg-secondary">{{ part.orderdetails | length }}</span>
+                    </a>
+                </li>
+            {% endif %}
 
-            </ul>
-            <div class="tab-content" id="myTabContent">
-                {% if part.comment is not empty %}
-                    <div class="tab-pane fade show" id="comment" role="tabpanel" aria-labelledby="home-tab">
-                        <div class="container-fluid mt-2 latex" data-controller="common--latex">
-                            {{ part.comment|format_markdown }}
-                        </div>
+            {% if part.associatedPartsAll is not empty %}
+                <li class="nav-item">
+                    <a class="nav-link" id="associations-tab" data-bs-toggle="tab" href="#associations" role="tab">
+                        <i class="fas fas fa-circle-nodes fa-fw fa-fw"></i>
+                        {% trans %}part.edit.tab.associations{% endtrans %}
+                        <span class="badge bg-secondary">{{ part.associatedPartsAll | length }}</span>
+                    </a>
+                </li>
+            {% endif %}
+
+            <li class="nav-item {% if datatable is null %}not-allowed{% endif %}">
+                <a class="nav-link {% if datatable is null %}disabled{% endif %}" id="history-tab" data-bs-toggle="tab" href="#history" role="tab">
+                    <i class="fas fa-history"></i>
+                    {% trans %}vendor.partinfo.history{% endtrans %}
+                </a>
+            </li>
+            {% if part.projectBomEntries is not empty %}
+                <li class="nav-item">
+                    <a class="nav-link" id="projects-tab" data-bs-toggle="tab" href="#projects" role="tab">
+                        <i class="fas fa-archive fa-fw"></i>
+                        {% trans %}project.labelp{% endtrans %}
+                        <span class="badge bg-secondary">{{ part.projectBomEntries | length }}</span>
+                    </a>
+                </li>
+            {% endif %}
+            <li class="nav-item">
+                <a class="nav-link" id="tools-tab" data-bs-toggle="tab" href="#tools" role="tab">
+                    <i class="fas fa-tools"></i>
+                    {% trans %}tools.label{% endtrans %}
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" id="extended_info-tab" data-bs-toggle="tab" href="#extended_info" role="tab">
+                    <i class="fas fa-clipboard-list"></i>
+                    {% trans %}extended_info.label{% endtrans %}
+                </a>
+            </li>
+
+        </ul>
+        <div class="tab-content" id="myTabContent">
+            {% if part.comment is not empty %}
+                <div class="tab-pane fade show" id="comment" role="tabpanel" aria-labelledby="home-tab">
+                    <div class="container-fluid mt-2 latex" data-controller="common--latex">
+                        {{ part.comment|format_markdown }}
                     </div>
-                {% endif %}
-
-                <div class="tab-pane fade show active" id="part_lots" role="tabpanel" aria-labelledby="part_lots-tab">
-                    {% include "parts/info/_part_lots.html.twig" %}
                 </div>
+            {% endif %}
 
-                {% if part.attachments is not empty %}
-                    <div class="tab-pane fade" id="attachments" role="tabpanel" aria-labelledby="attachment-tab">
-                        {% include "parts/info/_attachments_info.html.twig" %}
-                    </div>
-                {% endif %}
+            <div class="tab-pane fade show active" id="part_lots" role="tabpanel" aria-labelledby="part_lots-tab">
+                {% include "parts/info/_part_lots.html.twig" %}
+            </div>
 
-                {% if part.orderdetails is not empty %}
-                <div class="tab-pane fade" id="suppliers" role="tabpanel" aria-labelledby="supplier-tab">
-                    {%  include "parts/info/_order_infos.html.twig" %}
+            {% if part.attachments is not empty %}
+                <div class="tab-pane fade" id="attachments" role="tabpanel" aria-labelledby="attachment-tab">
+                    {% include "parts/info/_attachments_info.html.twig" %}
                 </div>
-                {% endif %}
+            {% endif %}
 
-                {% if part.associatedPartsAll is not empty %}
-                    <div class="tab-pane fade" id="associations" role="tabpanel" aria-labelledby="associations-tab">
-                        {%  include "parts/info/_associations.html.twig" %}
-                    </div>
-                {% endif %}
+            {% if part.orderdetails is not empty %}
+            <div class="tab-pane fade" id="suppliers" role="tabpanel" aria-labelledby="supplier-tab">
+                {%  include "parts/info/_order_infos.html.twig" %}
+            </div>
+            {% endif %}
 
-                <div class="tab-pane fade" id="projects" role="tabpanel" aria-labelledby="projects-tab">
-                    {% include "parts/info/_projects.html.twig" %}
+            {% if part.associatedPartsAll is not empty %}
+                <div class="tab-pane fade" id="associations" role="tabpanel" aria-labelledby="associations-tab">
+                    {%  include "parts/info/_associations.html.twig" %}
                 </div>
+            {% endif %}
 
-                <div class="tab-pane fade" id="history" role="tabpanel" aria-labelledby="history-tab">
-                    {% include "parts/info/_history.html.twig" %}
+            <div class="tab-pane fade" id="projects" role="tabpanel" aria-labelledby="projects-tab">
+                {% include "parts/info/_projects.html.twig" %}
+            </div>
+
+            <div class="tab-pane fade" id="history" role="tabpanel" aria-labelledby="history-tab">
+                {% include "parts/info/_history.html.twig" %}
+            </div>
+
+            <div class="tab-pane fade" id="tools" role="tabpanel" aria-labelledby="tools-tab">
+                {% include "parts/info/_tools.html.twig" %}
+            </div>
+
+            {% if part.parameters is not empty or description_params is not empty or comment_params is not empty %}
+                <div class="tab-pane fade" id="specifications" role="tabpanel" aria-labelledby="tools-tab">
+                    {% include "parts/info/_specifications.html.twig" %}
                 </div>
+            {% endif %}
 
-                <div class="tab-pane fade" id="tools" role="tabpanel" aria-labelledby="tools-tab">
-                    {% include "parts/info/_tools.html.twig" %}
-                </div>
+            <div class="tab-pane fade" id="extended_info" role="tabpanel" aria-labelledby="extended_info-tab">
 
-                {% if part.parameters is not empty or description_params is not empty or comment_params is not empty %}
-                    <div class="tab-pane fade" id="specifications" role="tabpanel" aria-labelledby="tools-tab">
-                        {% include "parts/info/_specifications.html.twig" %}
-                    </div>
-                {% endif %}
+                {% include "parts/info/_extended_infos.html.twig" %}
 
-                <div class="tab-pane fade" id="extended_info" role="tabpanel" aria-labelledby="extended_info-tab">
-
-                    {% include "parts/info/_extended_infos.html.twig" %}
-
-                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Some tweaks to better support mobile widths. The diff here doesn't look great owing to some larger markup/nesting changes, but here's what's happening:

- Tweak the data tables layout, as it appears it was using some Bootstrap 4 markup that's no longer valid
- Tweak the single part info, mainly making the image full-width and smaller screen sizes so that the image slider is usable and therefore the other two columns have more width to display in
- Added some more checks around part properties so no empty markup is output
- Converted the displayed part properties into a `<dl>` Description List and removed the use of `<h6>`, as this is a better semantic fit. Also provided more accessible markup while retaining the tooltips

If this final change to `<dl>`'s looks okay to you, I'm also working on doing the same thing to the single part "sidebar" and can submit a PR for that too