### PR TITLE
Show when parts from info provider already exist

### DIFF
--- a/src/Controller/InfoProviderController.php
+++ b/src/Controller/InfoProviderController.php
@@ -75,31 +75,31 @@ class InfoProviderController extends  AbstractController
     private function matchResultsToKnownParts(array $partsList): array
     {
         //we need a manufacturer object to look for a manufacturer
-        $manufacturerQb = $this->em->getRepository(Manufacturer::class)->createQueryBuilder("manufacturer");
-        $manufacturerQb->where($manufacturerQb->expr()->like("LOWER(manufacturer.name)", "LOWER(:manufacturer_name)"));
+        $manufacturerQb = $this->em->getRepository(Manufacturer::class)->createQueryBuilder('manufacturer');
+        $manufacturerQb->where($manufacturerQb->expr()->like('LOWER(manufacturer.name)', 'LOWER(:manufacturer_name)'));
 
 
         //check if both manufacturer and Manufacturer part namber matches. If so, it must be the same part
         //use LOWER to make the search independent of case
-        $mpnQb = $this->em->getRepository(Part::class)->createQueryBuilder("part");
-        $mpnQb->where($mpnQb->expr()->like("LOWER(part.manufacturer_product_number)", "LOWER(:mpn)"));
-        $mpnQb->andWhere($mpnQb->expr()->eq("part.manufacturer", ":manufacturer"));
+        $mpnQb = $this->em->getRepository(Part::class)->createQueryBuilder('part');
+        $mpnQb->where($mpnQb->expr()->like('LOWER(part.manufacturer_product_number)', 'LOWER(:mpn)'));
+        $mpnQb->andWhere($mpnQb->expr()->eq('part.manufacturer', ':manufacturer'));
 
         foreach ($partsList as $index => $part) {
-            $manufacturerQb->setParameter("manufacturer_name", $part["dto"]->manufacturer);
+            $manufacturerQb->setParameter('manufacturer_name', $part['dto']->manufacturer);
             $manufacturers = $manufacturerQb->getQuery()->getResult();
             if(!$manufacturers) {
                 continue;
             }
 
-            $mpnQb->setParameter("manufacturer", $manufacturers);
-            $mpnQb->setParameter("mpn", $part["dto"]->mpn);
+            $mpnQb->setParameter('manufacturer', $manufacturers);
+            $mpnQb->setParameter('mpn', $part['dto']->mpn);
             $localParts = $mpnQb->getQuery()->getResult();
             if(!$localParts) {
                 continue;
             }
             //We only use the first matching part. If a user already has duplicate parts they will get a random one
-            $partsList[$index]["localPart"] = $localParts[0];
+            $partsList[$index]['localPart'] = $localParts[0];
         }
         return $partsList;
     }
@@ -136,7 +136,7 @@ class InfoProviderController extends  AbstractController
             // modify the array to an array of arrays that has a field for a matching local Part
             // the advantage to use that format even when we don't look for local parts is that we
             // always work with the same interface
-            $results = array_map(function ($result) {return ["dto" => $result,"localPart" => null];}, $results);
+            $results = array_map(function ($result) {return ['dto' => $result, 'localPart' => null];}, $results);
             if(!$update_target) {
                 $results = $this->matchResultsToKnownParts($results);
             }

--- a/src/Services/InfoProviderSystem/ExistingPartFinder.php
+++ b/src/Services/InfoProviderSystem/ExistingPartFinder.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Services\InfoProviderSystem;
+
+use App\Entity\Parts\Manufacturer;
+use App\Entity\Parts\Part;
+use App\Services\InfoProviderSystem\DTOs\SearchResultDTO;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * This service assists in finding existing local parts for a SearchResultDTO, so that the user
+ * does not accidentally add a duplicate.
+ */
+final class ExistingPartFinder
+{
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+
+    }
+
+    /**
+     * Return the first existing local part, that matches the search result.
+     * If no part is found, return null.
+     * @param SearchResultDTO $dto
+     * @return Part|null
+     */
+    public function findFirstExisting(SearchResultDTO $dto): ?Part
+    {
+        $results = $this->findAllExisting($dto);
+        return count($results) > 0 ? $results[0] : null;
+    }
+
+    /**
+     * Returns all existing local parts that match the search result.
+     * If no part is found, return an empty array.
+     * @param SearchResultDTO $dto
+     * @return Part[]
+     */
+    public function findAllExisting(SearchResultDTO $dto): array
+    {
+        $qb = $this->em->getRepository(Part::class)->createQueryBuilder('part');
+        $qb->select('part')
+            ->leftJoin('part.manufacturer', 'manufacturer')
+            //The manufacturer name must match
+            ->where("ILIKE(manufacturer.name, :manufacturerName) = TRUE")
+            //And the manufacturer product number must match
+            ->andWhere(
+                "ILIKE(part.manufacturer_product_number, :mpn) = TRUE"
+            );
+
+        $qb->setParameter('manufacturerName', $dto->manufacturer);
+        $qb->setParameter('mpn', $dto->mpn);
+
+        return $qb->getQuery()->getResult();
+    }
+}

--- a/src/Services/InfoProviderSystem/ExistingPartFinder.php
+++ b/src/Services/InfoProviderSystem/ExistingPartFinder.php
@@ -41,12 +41,22 @@ final class ExistingPartFinder
         $qb = $this->em->getRepository(Part::class)->createQueryBuilder('part');
         $qb->select('part')
             ->leftJoin('part.manufacturer', 'manufacturer')
-            //The manufacturer name must match
-            ->where("ILIKE(manufacturer.name, :manufacturerName) = TRUE")
-            //And the manufacturer product number must match
-            ->andWhere(
-                "ILIKE(part.manufacturer_product_number, :mpn) = TRUE"
-            );
+            ->Orwhere($qb->expr()->andX(
+                'part.providerReference.provider_key = :providerKey',
+                'part.providerReference.provider_id = :providerId',
+            ))
+
+            //Or the manufacturer and the MPN must match
+            ->OrWhere(
+                $qb->expr()->andX(
+                    "ILIKE(manufacturer.name, :manufacturerName) = TRUE",
+                    "ILIKE(part.manufacturer_product_number, :mpn) = TRUE"
+                )
+            )
+        ;
+
+        $qb->setParameter('providerKey', $dto->provider_key);
+        $qb->setParameter('providerId', $dto->provider_id);
 
         $qb->setParameter('manufacturerName', $dto->manufacturer);
         $qb->setParameter('mpn', $dto->mpn);

--- a/templates/info_providers/search/part_search.html.twig
+++ b/templates/info_providers/search/part_search.html.twig
@@ -133,14 +133,24 @@
                                        target="_blank" title="{% trans %}info_providers.search.show_existing_part{% endtrans %}">
                                         <i class="fa-solid fa-search"></i>
                                     </a>
-                                    <a class="btn btn-primary" href="{{ path('part_edit', {'id': localPart.id}) }}"
-                                       target="_blank" title="{% trans %}info_providers.search.edit_existing_part{% endtrans %}">
-                                        <i class="fa-solid fa-pencil"></i>
+                                    <a class="btn btn-primary" href="{{ path("info_providers_update_part", {'id': localPart.id, 'providerKey': dto.provider_key, 'providerId': dto.provider_id}) }}"
+                                       target="_blank" title="{% trans %}info_providers.search.update_existing_part{% endtrans %}">
+                                        <i class="fa-solid fa-arrows-rotate"></i>
                                     </a>
-                                    <a class="btn btn-primary" href="{{ href }}"
-                                       target="_blank" title="{% trans %}part.create.btn{% endtrans %}">
-                                        <i class="fa-solid fa-plus-square"></i>
-                                    </a>
+                                    <div class="btn-group" role="group">
+                                        <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"></button>
+
+                                        <ul class="dropdown-menu">
+                                            <li><a class="dropdown-item" href="{{ path('part_edit', {'id': localPart.id}) }}" target="_blank">
+                                                    <i class="fa-solid fa-pencil fa-fw"></i> {% trans %}info_providers.search.edit_existing_part{% endtrans %}
+                                                </a></li>
+                                            <li>
+                                                <a class="dropdown-item" href="{{ href }}" target="_blank">
+                                                    <i class="fa-solid fa-plus-square fa-fw"></i> {% trans %}part.create.btn{% endtrans %}
+                                                </a>
+                                            </li>
+                                        </ul>
+                                    </div>
                                 </div>
 
                             {% endif %}

--- a/templates/info_providers/search/part_search.html.twig
+++ b/templates/info_providers/search/part_search.html.twig
@@ -53,6 +53,7 @@
                     <th>{% trans %}info_providers.table.provider.label{% endtrans %}</th>
                     <th></th>
                     <th></th>
+                    <th></th>
                 </tr>
                 </thead>
                 <tbody>
@@ -73,6 +74,9 @@
                             {% if dto.mpn is not null %}
                                 <br>
                                 <small class="text-muted" title="{% trans %}part.table.mpn{% endtrans %}">{{ dto.mpn }}</small>
+                            {% endif %}
+                            {%  if result["localPart"] is not null %}
+
                             {% endif %}
                         </td>
                         <td>
@@ -100,6 +104,17 @@
                             {% endif %}
                             <br>
                             <small class="text-muted">{{ dto.provider_id }}</small>
+                        </td>
+                        <td>
+                            {# TODO: would like to have a sort of "part exists!" text here, but don't know how to style it
+                            also it would be nice to have these two buttons closer together, but when I put them in one cell
+                            they sometimes stack#}
+                            {% if result["localPart"] is not null %}
+                                <a class="btn btn-primary" href="{{ path('app_part_show', {'id': result['localPart'].id}) }}"
+                                   target="_blank" title="Show Existing Part"> {# TODO: Needs translation #}
+                                    <i class="fa-solid fa-search"></i>
+                                </a>
+                            {% endif %}
                         </td>
                         <td>
                             {% if result["localPart"] is not null %}

--- a/templates/info_providers/search/part_search.html.twig
+++ b/templates/info_providers/search/part_search.html.twig
@@ -52,59 +52,71 @@
                     <th>{% trans %}part.table.manufacturingStatus{% endtrans %}</th>
                     <th>{% trans %}info_providers.table.provider.label{% endtrans %}</th>
                     <th></th>
+                    <th></th>
                 </tr>
                 </thead>
                 <tbody>
                 {% for result in results  %}
+                    {% set dto = result["dto"] %}
                     <tr>
                         <td>
-                            <img src="{{ result.preview_image_url }}" data-thumbnail="{{ result.preview_image_url }}"
+                            <img src="{{ dto.preview_image_url }}" data-thumbnail="{{ dto.preview_image_url }}"
                                  class="hoverpic" style="max-width: 45px;" {{ stimulus_controller('elements/hoverpic') }}>
                         </td>
                         <td>
-                            {% if result.provider_url is not null %}
-                                <a href="{{ result.provider_url }}" target="_blank" rel="noopener">{{ result.name }}</a>
+                            {% if dto.provider_url is not null %}
+                                <a href="{{ dto.provider_url }}" target="_blank" rel="noopener">{{ dto.name }}</a>
                             {% else %}
-                                {{ result.name }}
+                                {{ dto.name }}
                             {% endif %}
 
-                            {% if result.mpn is not null %}
+                            {% if dto.mpn is not null %}
                                 <br>
-                                <small class="text-muted" title="{% trans %}part.table.mpn{% endtrans %}">{{ result.mpn }}</small>
+                                <small class="text-muted" title="{% trans %}part.table.mpn{% endtrans %}">{{ dto.mpn }}</small>
                             {% endif %}
                         </td>
                         <td>
-                            {{ result.description }}
-                            {% if result.category is not null %}
+                            {{ dto.description }}
+                            {% if dto.category is not null %}
                                 <br>
-                                <small class="text-muted">{{ result.category }}</small>
+                                <small class="text-muted">{{ dto.category }}</small>
                             {% endif %}
                         </td>
                         <td>
-                            {{ result.manufacturer ?? '' }}
-                            {% if result.footprint is not null %}
+                            {{ dto.manufacturer ?? '' }}
+                            {% if dto.footprint is not null %}
                                 <br>
-                                <small class="text-muted">{{ result.footprint }}</small>
+                                <small class="text-muted">{{ dto.footprint }}</small>
                             {% endif %}
                         </td>
-                        <td>{{ helper.m_status_to_badge(result.manufacturing_status) }}</td>
+                        <td>{{ helper.m_status_to_badge(dto.manufacturing_status) }}</td>
                         <td>
-                            {% if result.provider_url %}
-                                <a href="{{ result.provider_url }}" target="_blank" rel="noopener">
-                                    {{ info_provider_label(result.provider_key)|default(result.provider_key) }}
+                            {% if dto.provider_url %}
+                                <a href="{{ dto.provider_url }}" target="_blank" rel="noopener">
+                                    {{ info_provider_label(dto.provider_key)|default(dto.provider_key) }}
                                 </a>
                             {% else %}
-                                {{ info_provider_label(result.provider_key)|default(result.provider_key) }}
+                                {{ info_provider_label(dto.provider_key)|default(dto.provider_key) }}
                             {% endif %}
                             <br>
-                            <small class="text-muted">{{ result.provider_id }}</small>
+                            <small class="text-muted">{{ dto.provider_id }}</small>
+                        </td>
                         <td>
+                            {% if result["localPart"] is not null %}
+                                <a class="btn btn-primary" href="{{ path('part_edit', {'id': result['localPart'].id}) }}"
+                                   target="_blank" title="Edit Existing Part"> {# TODO: Needs translation #}
+                                    <i class="fa-solid fa-pencil"></i>
+                                </a>
+                            {% endif %}
+                        </td>
+                        <td>
+
                             {% if update_target %} {# We update an existing part #}
                                 {% set href = path('info_providers_update_part',
-                                    {'providerKey': result.provider_key, 'providerId': result.provider_id, 'id': update_target.iD}) %}
+                                    {'providerKey': dto.provider_key, 'providerId': dto.provider_id, 'id': update_target.iD}) %}
                             {% else %} {# Create a fresh part #}
                                 {% set href = path('info_providers_create_part',
-                                    {'providerKey': result.provider_key, 'providerId': result.provider_id}) %}
+                                    {'providerKey': dto.provider_key, 'providerId': dto.provider_id}) %}
                             {% endif %}
 
                             <a class="btn btn-primary" href="{{ href }}"

--- a/templates/info_providers/search/part_search.html.twig
+++ b/templates/info_providers/search/part_search.html.twig
@@ -52,8 +52,6 @@
                     <th>{% trans %}part.table.manufacturingStatus{% endtrans %}</th>
                     <th>{% trans %}info_providers.table.provider.label{% endtrans %}</th>
                     <th></th>
-                    <th></th>
-                    <th></th>
                 </tr>
                 </thead>
                 <tbody>
@@ -108,26 +106,7 @@
                             <br>
                             <small class="text-muted">{{ dto.provider_id }}</small>
                         </td>
-                        <td>
-                            {# TODO: would like to have a sort of "part exists!" text here, but don't know how to style it
-                            also it would be nice to have these two buttons closer together, but when I put them in one cell
-                            they sometimes stack#}
-                            {% if localPart is not null %}
-                                <a class="btn btn-primary" href="{{ path('app_part_show', {'id': localPart.id}) }}"
-                                   target="_blank" title="{% trans %}info_providers.search.show_existing_part{% endtrans %}">
-                                    <i class="fa-solid fa-search"></i>
-                                </a>
-                            {% endif %}
-                        </td>
-                        <td>
-                            {% if localPart is not null %}
-                                <a class="btn btn-primary" href="{{ path('part_edit', {'id': localPart.id}) }}"
-                                   target="_blank" title="{% trans %}info_providers.search.edit_existing_part{% endtrans %}">
-                                    <i class="fa-solid fa-pencil"></i>
-                                </a>
-                            {% endif %}
-                        </td>
-                        <td>
+                        <td class="text-center">
 
                             {% if update_target %} {# We update an existing part #}
                                 {% set href = path('info_providers_update_part',
@@ -137,10 +116,34 @@
                                     {'providerKey': dto.provider_key, 'providerId': dto.provider_id}) %}
                             {% endif %}
 
-                            <a class="btn btn-primary" href="{{ href }}"
-                               target="_blank" title="{% trans %}part.create.btn{% endtrans %}">
-                                <i class="fa-solid fa-plus-square"></i>
-                            </a>
+                            {# If we have no local part, then we can just show the create button #}
+                            {% if localPart is null %}
+                                <a class="btn btn-primary" href="{{ href }}"
+                                target="_blank" title="{% trans %}part.create.btn{% endtrans %}">
+                                    <i class="fa-solid fa-plus-square"></i>
+                                </a>
+                            {% else %} {#  Otherwise add a button group with all three buttons #}
+                                <span class="badge text-bg-warning mb-1 d-block" title="{% trans %}info_providers.search.existing_part_found{% endtrans %}">
+                                    <i class="fa-solid fa-circle-info fa-fw"></i>
+                                    {% trans %}info_providers.search.existing_part_found.short{% endtrans %}
+                                </span>
+
+                                <div class="btn-group" role="group">
+                                    <a class="btn btn-primary" href="{{ path('app_part_show', {'id': localPart.id}) }}"
+                                       target="_blank" title="{% trans %}info_providers.search.show_existing_part{% endtrans %}">
+                                        <i class="fa-solid fa-search"></i>
+                                    </a>
+                                    <a class="btn btn-primary" href="{{ path('part_edit', {'id': localPart.id}) }}"
+                                       target="_blank" title="{% trans %}info_providers.search.edit_existing_part{% endtrans %}">
+                                        <i class="fa-solid fa-pencil"></i>
+                                    </a>
+                                    <a class="btn btn-primary" href="{{ href }}"
+                                       target="_blank" title="{% trans %}part.create.btn{% endtrans %}">
+                                        <i class="fa-solid fa-plus-square"></i>
+                                    </a>
+                                </div>
+
+                            {% endif %}
                         </td>
                     </tr>
                 {% endfor %}

--- a/templates/info_providers/search/part_search.html.twig
+++ b/templates/info_providers/search/part_search.html.twig
@@ -62,7 +62,7 @@
                     {# @var App\Entity\Parts\Part localPart #}
                     {% set localPart = result["localPart"] %}
 
-                    <tr >
+                    <tr {% if localPart is not null %}class="table-warning"{% endif %}>
                         <td>
                             <img src="{{ dto.preview_image_url }}" data-thumbnail="{{ dto.preview_image_url }}"
                                  class="hoverpic" style="max-width: 45px;" {{ stimulus_controller('elements/hoverpic') }}>

--- a/templates/info_providers/search/part_search.html.twig
+++ b/templates/info_providers/search/part_search.html.twig
@@ -114,7 +114,7 @@
                             they sometimes stack#}
                             {% if localPart is not null %}
                                 <a class="btn btn-primary" href="{{ path('app_part_show', {'id': localPart.id}) }}"
-                                   target="_blank" title="Show Existing Part"> {# TODO: Needs translation #}
+                                   target="_blank" title="{% trans %}info_providers.search.show_existing_part{% endtrans %}">
                                     <i class="fa-solid fa-search"></i>
                                 </a>
                             {% endif %}
@@ -122,7 +122,7 @@
                         <td>
                             {% if localPart is not null %}
                                 <a class="btn btn-primary" href="{{ path('part_edit', {'id': localPart.id}) }}"
-                                   target="_blank" title="Edit Existing Part"> {# TODO: Needs translation #}
+                                   target="_blank" title="{% trans %}info_providers.search.edit_existing_part{% endtrans %}">
                                     <i class="fa-solid fa-pencil"></i>
                                 </a>
                             {% endif %}

--- a/templates/info_providers/search/part_search.html.twig
+++ b/templates/info_providers/search/part_search.html.twig
@@ -59,7 +59,10 @@
                 <tbody>
                 {% for result in results  %}
                     {% set dto = result["dto"] %}
-                    <tr>
+                    {# @var App\Entity\Parts\Part localPart #}
+                    {% set localPart = result["localPart"] %}
+
+                    <tr >
                         <td>
                             <img src="{{ dto.preview_image_url }}" data-thumbnail="{{ dto.preview_image_url }}"
                                  class="hoverpic" style="max-width: 45px;" {{ stimulus_controller('elements/hoverpic') }}>
@@ -109,16 +112,16 @@
                             {# TODO: would like to have a sort of "part exists!" text here, but don't know how to style it
                             also it would be nice to have these two buttons closer together, but when I put them in one cell
                             they sometimes stack#}
-                            {% if result["localPart"] is not null %}
-                                <a class="btn btn-primary" href="{{ path('app_part_show', {'id': result['localPart'].id}) }}"
+                            {% if localPart is not null %}
+                                <a class="btn btn-primary" href="{{ path('app_part_show', {'id': localPart.id}) }}"
                                    target="_blank" title="Show Existing Part"> {# TODO: Needs translation #}
                                     <i class="fa-solid fa-search"></i>
                                 </a>
                             {% endif %}
                         </td>
                         <td>
-                            {% if result["localPart"] is not null %}
-                                <a class="btn btn-primary" href="{{ path('part_edit', {'id': result['localPart'].id}) }}"
+                            {% if localPart is not null %}
+                                <a class="btn btn-primary" href="{{ path('part_edit', {'id': localPart.id}) }}"
                                    target="_blank" title="Edit Existing Part"> {# TODO: Needs translation #}
                                     <i class="fa-solid fa-pencil"></i>
                                 </a>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -12251,5 +12251,11 @@ Please note, that you can not impersonate a disabled user. If you try you will g
         <target>This part (or a very similar one) was already found in the database. Please check if it is the same and if you want to create it again!</target>
       </segment>
     </unit>
+    <unit id="TDxYuTP" name="info_providers.search.update_existing_part">
+      <segment>
+        <source>info_providers.search.update_existing_part</source>
+        <target>Update existing part from info provider</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -12227,5 +12227,17 @@ Please note, that you can not impersonate a disabled user. If you try you will g
         <target>Generated code</target>
       </segment>
     </unit>
+    <unit id="5fgkpRc" name="info_providers.search.show_existing_part">
+      <segment>
+        <source>info_providers.search.show_existing_part</source>
+        <target>Show existing part</target>
+      </segment>
+    </unit>
+    <unit id="iPO8lit" name="info_providers.search.edit_existing_part">
+      <segment>
+        <source>info_providers.search.edit_existing_part</source>
+        <target>Edit existing part</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -12239,5 +12239,17 @@ Please note, that you can not impersonate a disabled user. If you try you will g
         <target>Edit existing part</target>
       </segment>
     </unit>
+    <unit id="gUMm8CJ" name="info_providers.search.existing_part_found.short">
+      <segment>
+        <source>info_providers.search.existing_part_found.short</source>
+        <target>Part already existing</target>
+      </segment>
+    </unit>
+    <unit id="bT1nkI9" name="info_providers.search.existing_part_found">
+      <segment>
+        <source>info_providers.search.existing_part_found</source>
+        <target>This part (or a very similar one) was already found in the database. Please check if it is the same and if you want to create it again!</target>
+      </segment>
+    </unit>
   </file>
 </xliff>


### PR DESCRIPTION
When adding the new part via the info provider system, the system would make a new part, regardless of the identical old one. I changed the info provider service to look for each part that is listed in the info provider search results and add a button to view the existing part if one exists. 

**Translations:**
No idea how to add those, but needs to be done

**Style:** 
Currently the layout is functional, but I would like some clearer notice that the buttons are there because the part was found locally. Because the row is already quite full and there's not much space to add info I would ideally have liked it to look something like this:
![image](https://github.com/user-attachments/assets/b6d80b39-405e-4e62-85b9-5deb7f43d1ac)
(Screenshot of a random webpage for illustration purposes) 
I'm not great at html/css though and adding a dummy row doesn't play well with the striped layout of the table.
