### PR TITLE
Fixed attachment statistics for sqlite

### DIFF
--- a/src/Repository/AttachmentRepository.php
+++ b/src/Repository/AttachmentRepository.php
@@ -58,8 +58,8 @@ class AttachmentRepository extends DBElementRepository
     {
         $qb = $this->createQueryBuilder('attachment');
         $qb->select('COUNT(attachment)')
-            ->where('attachment.path LIKE :like');
-        $qb->setParameter('like', '\\%SECURE\\%%');
+            ->where('attachment.path LIKE :like ESCAPE \'#\'');
+        $qb->setParameter('like', '#%SECURE#%%');
         $query = $qb->getQuery();
 
         return (int) $query->getSingleScalarResult();
@@ -94,12 +94,12 @@ class AttachmentRepository extends DBElementRepository
     {
         $qb = $this->createQueryBuilder('attachment');
         $qb->select('COUNT(attachment)')
-            ->where('attachment.path LIKE :base')
-            ->orWhere('attachment.path LIKE :media')
-            ->orWhere('attachment.path LIKE :secure');
-        $qb->setParameter('secure', '\\%SECURE\\%%');
-        $qb->setParameter('base', '\\%BASE\\%%');
-        $qb->setParameter('media', '\\%MEDIA\\%%');
+            ->where('attachment.path LIKE :base ESCAPE \'#\'')
+            ->orWhere('attachment.path LIKE :media ESCAPE \'#\'')
+            ->orWhere('attachment.path LIKE :secure ESCAPE \'#\'');
+        $qb->setParameter('secure', '#%SECURE#%%');
+        $qb->setParameter('base', '#%BASE#%%');
+        $qb->setParameter('media', '#%MEDIA#%%');
         $query = $qb->getQuery();
 
         return (int) $query->getSingleScalarResult();


### PR DESCRIPTION
SQLite doesn't support the backslash as an escape character by default. Any escape character must be specified by the ESCAPE function. To avoid confusion when using other DBs which do recognize the backslash, but also the ESCAPE function I used # here.