### PR TITLE
Add supplier information to KiCad part exports

### DIFF
--- a/src/Services/EDA/KiCadHelper.php
+++ b/src/Services/EDA/KiCadHelper.php
@@ -237,6 +237,28 @@ class KiCadHelper
             $result["fields"]["Part-DB IPN"] = $this->createField($part->getIpn());
         }
 
+        // Add supplier information from orderdetails (include obsolete orderdetails)
+        if ($part->getOrderdetails(false)->count() > 0) {
+            $supplierCounts = [];
+            
+            foreach ($part->getOrderdetails(false) as $orderdetail) {
+                if ($orderdetail->getSupplier() !== null && $orderdetail->getSupplierPartNr() !== '') {
+                    $supplierName = $orderdetail->getSupplier()->getName();
+                    
+                    if (!isset($supplierCounts[$supplierName])) {
+                        $supplierCounts[$supplierName] = 0;
+                    }
+                    $supplierCounts[$supplierName]++;
+                    
+                    // Create field name with sequential number if more than one from same supplier (e.g. "Mouser", "Mouser 2", etc.)
+                    $fieldName = $supplierCounts[$supplierName] > 1 
+                        ? $supplierName . ' ' . $supplierCounts[$supplierName]
+                        : $supplierName;
+                    
+                    $result["fields"][$fieldName] = $this->createField($orderdetail->getSupplierPartNr());
+                }
+            }
+        }
 
         return $result;
     }

--- a/src/Services/EDA/KiCadHelper.php
+++ b/src/Services/EDA/KiCadHelper.php
@@ -244,7 +244,9 @@ class KiCadHelper
             foreach ($part->getOrderdetails(false) as $orderdetail) {
                 if ($orderdetail->getSupplier() !== null && $orderdetail->getSupplierPartNr() !== '') {
                     $supplierName = $orderdetail->getSupplier()->getName();
-                    
+
+                    $supplierName .= " SPN"; // Append "SPN" to the supplier name to indicate Supplier Part Number
+
                     if (!isset($supplierCounts[$supplierName])) {
                         $supplierCounts[$supplierName] = 0;
                     }


### PR DESCRIPTION
- Include supplier name and part numbers from order details in KiCad exports
- Handle multiple suppliers with sequential numbering (Supplier 2, Supplier 3, etc.)
- Include both active and obsolete order details for comprehensive supplier info
- Add null checks to prevent errors when supplier or part number is missing