### PR TITLE
Update AbstractParameter.php

### DIFF
--- a/assets/controllers/pages/latex_preview_controller.js
+++ b/assets/controllers/pages/latex_preview_controller.js
@@ -33,7 +33,10 @@ export default class extends Controller {
     {
         let value = "";
         if (this.unitValue) {
-            value = "\\mathrm{" + this.inputTarget.value + "}";
+            //Escape percentage signs
+            value = this.inputTarget.value.replace(/%/g, '\\%');
+
+            value = "\\mathrm{" + value + "}";
         } else {
             value = this.inputTarget.value;
         }

--- a/assets/controllers/pages/parameters_autocomplete_controller.js
+++ b/assets/controllers/pages/parameters_autocomplete_controller.js
@@ -85,7 +85,9 @@ export default class extends Controller
                         tmp += '<span>' + katex.renderToString(data.symbol) + '</span>'
                     }
                     if (data.unit) {
-                        tmp += '<span class="ms-2">' + katex.renderToString('[' + data.unit + ']') + '</span>'
+                        let unit  = data.unit.replace(/%/g, '\\%');
+                        unit = "\\mathrm{" + unit + "}";
+                        tmp += '<span class="ms-2">' + katex.renderToString('[' + unit + ']') + '</span>'
                     }
 
 

--- a/src/Entity/Parameters/AbstractParameter.php
+++ b/src/Entity/Parameters/AbstractParameter.php
@@ -449,29 +449,16 @@ abstract class AbstractParameter extends AbstractNamedDBElement implements Uniqu
             if (!$with_latex) {
                 $unit = $this->unit;
             } else {
-                // if chars occur that will mess up the latex formatting, display them plain, regardless of the desired output
-                if (str_contains($this->unit, '~') || str_contains($this->unit, '^') || str_contains($this->unit, '\\'))
-                {
-                    $unit = $this->unit;
-                }
-                else // otherwise, style the chars with latex, but escape latex special chars
-                {
-                    $unit = '$\mathrm{'.$this->latexEscape($this->unit).'}$';
-                }
+                //Escape the percentage sign for convenience (as latex uses it as comment and it is often used in units)
+                $escaped = preg_replace('/(\%)/', "\\\\$1", $this->unit);
+
+                $unit = '$\mathrm{'.$escaped.'}$';
             }
 
             return $str.' '.$unit;
         }
 
         return $str;
-    }
-    
-    /**
-     * Return a latex escaped string
-     */
-    protected function latexEscape(string $latex): string
-    {
-        return preg_replace('/(\&|\%|\$|\#|\_|\{|\})/', "\\\\$1", $latex);
     }
     
     /**

--- a/src/Entity/Parameters/AbstractParameter.php
+++ b/src/Entity/Parameters/AbstractParameter.php
@@ -217,7 +217,7 @@ abstract class AbstractParameter extends AbstractNamedDBElement implements Uniqu
 
         $str = '';
         $bracket_opened = false;
-        if ($this->value_typical) {
+        if ($this->value_typical !== null) {
             $str .= $this->getValueTypicalWithUnit($latex_formatted);
             if ($this->value_min || $this->value_max) {
                 $bracket_opened = true;
@@ -225,11 +225,11 @@ abstract class AbstractParameter extends AbstractNamedDBElement implements Uniqu
             }
         }
 
-        if ($this->value_max && $this->value_min) {
+        if ($this->value_max !== null && $this->value_min !== null) {
             $str .= $this->getValueMinWithUnit($latex_formatted).' ... '.$this->getValueMaxWithUnit($latex_formatted);
-        } elseif ($this->value_max) {
+        } elseif ($this->value_max !== null) {
             $str .= 'max. '.$this->getValueMaxWithUnit($latex_formatted);
-        } elseif ($this->value_min) {
+        } elseif ($this->value_min !== null) {
             $str .= 'min. '.$this->getValueMinWithUnit($latex_formatted);
         }
 
@@ -449,7 +449,15 @@ abstract class AbstractParameter extends AbstractNamedDBElement implements Uniqu
             if (!$with_latex) {
                 $unit = $this->unit;
             } else {
-                $unit = '$\mathrm{'.$this->unit.'}$';
+                // if chars occur that will mess up the latex formatting, display them plain, regardless of the desired output
+                if (str_contains($this->unit, '~') || str_contains($this->unit, '^') || str_contains($this->unit, '\\'))
+                {
+                    $unit = $this->unit;
+                }
+                else // otherwise, style the chars with latex, but escape latex special chars
+                {
+                    $unit = '$\mathrm{'.$this->latexEscape($this->unit).'}$';
+                }
             }
 
             return $str.' '.$unit;
@@ -457,7 +465,15 @@ abstract class AbstractParameter extends AbstractNamedDBElement implements Uniqu
 
         return $str;
     }
-
+    
+    /**
+     * Return a latex escaped string
+     */
+    protected function latexEscape(string $latex): string
+    {
+        return preg_replace('/(\&|\%|\$|\#|\_|\{|\})/', "\\\\$1", $latex);
+    }
+    
     /**
      * Returns the class of the element that is allowed to be associated with this attachment.
      * @return string

--- a/src/Entity/Parameters/AbstractParameter.php
+++ b/src/Entity/Parameters/AbstractParameter.php
@@ -450,7 +450,7 @@ abstract class AbstractParameter extends AbstractNamedDBElement implements Uniqu
                 $unit = $this->unit;
             } else {
                 //Escape the percentage sign for convenience (as latex uses it as comment and it is often used in units)
-                $escaped = preg_replace('/(\%)/', "\\\\$1", $this->unit);
+                $escaped = preg_replace('/([^\\\\]?%)/', "\\\\$1", $this->unit);
 
                 $unit = '$\mathrm{'.$escaped.'}$';
             }

--- a/src/Entity/Parameters/AbstractParameter.php
+++ b/src/Entity/Parameters/AbstractParameter.php
@@ -450,7 +450,7 @@ abstract class AbstractParameter extends AbstractNamedDBElement implements Uniqu
                 $unit = $this->unit;
             } else {
                 //Escape the percentage sign for convenience (as latex uses it as comment and it is often used in units)
-                $escaped = preg_replace('/([^\\\\]?%)/', "\\\\$1", $this->unit);
+                $escaped = preg_replace('/\\\\?%/', "\\\\%", $this->unit);
 
                 $unit = '$\mathrm{'.$escaped.'}$';
             }


### PR DESCRIPTION
Make lazy null conditionals explicit, thus enabling output of `0` as parameter value.
Try to handle LaTeX special chars gracefully (especially %, as seen in the referenced issue).
Fixes #958

(Javascript code will need some work too: the LaTeX controllers also don't handle special chars.
The parameter selection drop-down show some params incorrectly, e.g.  `Tolerance [%]` shows as `Tolerance[`.
The parameter preview shows an error e.g. when entering `%`; With `\%`, it works.)