### PR TITLE
UX: Always show the select panel

### DIFF
--- a/assets/controllers/elements/datatables/parts_controller.js
+++ b/assets/controllers/elements/datatables/parts_controller.js
@@ -42,11 +42,11 @@ export default class extends DatatablesController {
 
         const selectPanel = this.selectPanelTarget;
 
-        //Hide/Unhide panel with the selection tools
+        //Toggle action button based on selection
         if (count > 0) {
-            selectPanel.classList.remove('d-none');
+            document.getElementById("selectPanel_submit").disabled = false; 
         } else {
-            selectPanel.classList.add('d-none');
+            document.getElementById("selectPanel_submit").disabled = true; 
         }
 
         //Update selection count text

--- a/assets/controllers/elements/datatables/parts_controller.js
+++ b/assets/controllers/elements/datatables/parts_controller.js
@@ -42,11 +42,11 @@ export default class extends DatatablesController {
 
         const selectPanel = this.selectPanelTarget;
 
-        //Toggle action button based on selection
+        //Enable action button based on selection
         if (count > 0) {
-            document.getElementById("selectPanel_submit").disabled = false; 
+            selectPanel.querySelector('button[type="submit"]').disabled = false; 
         } else {
-            document.getElementById("selectPanel_submit").disabled = true; 
+            selectPanel.querySelector('button[type="submit"]').disabled = true; 
         }
 
         //Update selection count text

--- a/templates/components/datatables.macro.html.twig
+++ b/templates/components/datatables.macro.html.twig
@@ -79,7 +79,7 @@
                     {# This is left empty, as this will be filled by Javascript #}
                 </select>
 
-                <button id="selectPanel_submit" disabled type="submit" class="btn btn-primary">{% trans %}part_list.action.submit{% endtrans %}</button>
+                <button disabled type="submit" class="btn btn-primary">{% trans %}part_list.action.submit{% endtrans %}</button>
             </div>
         </div>
 

--- a/templates/components/datatables.macro.html.twig
+++ b/templates/components/datatables.macro.html.twig
@@ -29,14 +29,14 @@
 
         <input type="hidden" name="ids" {{ stimulus_target('elements/datatables/parts', 'selectIDs') }} value="">
 
-        <div class="d-none mb-2" {{ stimulus_target('elements/datatables/parts', 'selectPanel') }}>
+        <div class="mb-2" {{ stimulus_target('elements/datatables/parts', 'selectPanel') }}>
             {# <span id="select_count"></span> #}
 
             <div class="input-group">
                 <button class="btn btn-outline-secondary" type="button" {{ stimulus_action('elements/datatables/parts', 'invertSelection')}}
                         title="{% trans %}part_list.action.invert_selection{% endtrans %}" ><i class="fa-solid fa-arrow-right-arrow-left"></i></button>
                 <span class="input-group-text">
-                    <span class="badge bg-primary">{% trans with {'%count%': '<span ' ~ stimulus_target('elements/datatables/parts', 'selectCount') ~ '></span>'} %}part_list.action.part_count{% endtrans %}</span>
+                    <span class="badge bg-primary">{% trans with {'%count%': '<span ' ~ stimulus_target('elements/datatables/parts', 'selectCount') ~ '>0</span>'} %}part_list.action.part_count{% endtrans %}</span>
                 </span>
 
                 <select class="form-select" name="action" data-controller="elements--select" {{ stimulus_action('elements/datatables/parts', 'updateTargetPicker', 'change') }}
@@ -79,7 +79,7 @@
                     {# This is left empty, as this will be filled by Javascript #}
                 </select>
 
-                <button type="submit" class="btn btn-primary">{% trans %}part_list.action.submit{% endtrans %}</button>
+                <button id="selectPanel_submit" disabled type="submit" class="btn btn-primary">{% trans %}part_list.action.submit{% endtrans %}</button>
             </div>
         </div>
 

--- a/translations/messages.cs.xlf
+++ b/translations/messages.cs.xlf
@@ -9018,7 +9018,7 @@ Element 3</target>
     <unit id="qKDo_nI" name="part_list.action.part_count">
       <segment state="translated">
         <source>part_list.action.part_count</source>
-        <target>%count% dílů vybráno!</target>
+        <target>%count% dílů vybráno</target>
       </segment>
     </unit>
     <unit id="ssOogP5" name="company.edit.quick.website">

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -9006,7 +9006,7 @@ Element 3</target>
     <unit id="gaoMsrY" name="part_list.action.part_count">
       <segment state="translated">
         <source>part_list.action.part_count</source>
-        <target>%count% Bauteile ausgewählt!</target>
+        <target>%count% Bauteile ausgewählt</target>
       </segment>
     </unit>
     <unit id="FhdheZY" name="company.edit.quick.website">

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -9010,7 +9010,7 @@ Element 3</target>
     <unit id="gaoMsrY" name="part_list.action.part_count">
       <segment state="translated">
         <source>part_list.action.part_count</source>
-        <target>%count% parts selected!</target>
+        <target>%count% parts selected</target>
       </segment>
     </unit>
     <unit id="FhdheZY" name="company.edit.quick.website">

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -9009,7 +9009,7 @@ Elemento 3</target>
     <unit id="gaoMsrY" name="part_list.action.part_count">
       <segment state="translated">
         <source>part_list.action.part_count</source>
-        <target>¡%count% componentes seleccionadas!</target>
+        <target>¡%count% componentes seleccionadas</target>
       </segment>
     </unit>
     <unit id="FhdheZY" name="company.edit.quick.website">

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -8932,7 +8932,7 @@ exemple de ville</target>
     <unit id="qKDo_nI" name="part_list.action.part_count">
       <segment state="translated">
         <source>part_list.action.part_count</source>
-        <target>%count% composants sélectionnés !</target>
+        <target>%count% composants sélectionnés</target>
       </segment>
     </unit>
     <unit id="ssOogP5" name="company.edit.quick.website">

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -9011,7 +9011,7 @@ Element 3</target>
     <unit id="gaoMsrY" name="part_list.action.part_count">
       <segment state="translated">
         <source>part_list.action.part_count</source>
-        <target>%count% componenti selezionati !</target>
+        <target>%count% componenti selezionati</target>
       </segment>
     </unit>
     <unit id="FhdheZY" name="company.edit.quick.website">

--- a/translations/messages.pl.xlf
+++ b/translations/messages.pl.xlf
@@ -9014,7 +9014,7 @@ Element 3</target>
     <unit id="gaoMsrY" name="part_list.action.part_count">
       <segment state="translated">
         <source>part_list.action.part_count</source>
-        <target>Wybrano %count% części!</target>
+        <target>Wybrano %count% części</target>
       </segment>
     </unit>
     <unit id="FhdheZY" name="company.edit.quick.website">

--- a/translations/messages.ru.xlf
+++ b/translations/messages.ru.xlf
@@ -9018,7 +9018,7 @@
     <unit id="gaoMsrY" name="part_list.action.part_count">
       <segment state="translated">
         <source>part_list.action.part_count</source>
-        <target>%count% компонентов выбрано!</target>
+        <target>%count% компонентов выбрано</target>
       </segment>
     </unit>
     <unit id="FhdheZY" name="company.edit.quick.website">


### PR DESCRIPTION
Make the select panel always visible because several user reports suggest that they are unaware of the feature.
Also solves the minor issue that selecting/deselecting a single row changes the position of the table which makes it prone to misclicks.

Note: Translations have been adjusted in place, changes should be reflected in crowdin in case this will be merged.