### PR TITLE
Add import permission for label profiles

### DIFF
--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -359,6 +359,10 @@ perms: # Here comes a list with all Permission names (they have a perm_[name] co
         label: "perm.revert_elements"
         alsoSet: ['read_profiles', 'edit_profiles', 'create_profiles', 'delete_profiles']
         apiTokenRole: ROLE_API_EDIT
+      import:
+        label: "perm.import"
+        alsoSet: ['read_profiles', 'edit_profiles', 'create_profiles' ]
+        apiTokenRole: ROLE_API_EDIT
 
   api:
     label: "perm.api"

--- a/src/Security/Voter/LabelProfileVoter.php
+++ b/src/Security/Voter/LabelProfileVoter.php
@@ -58,6 +58,7 @@ final class LabelProfileVoter extends Voter
         'delete' => 'delete_profiles',
         'show_history' => 'show_history',
         'revert_element' => 'revert_element',
+        'import' => 'import',
     ];
 
     public function __construct(private readonly VoterHelper $helper)


### PR DESCRIPTION
Fixes #1020.

In the long run, I think the permissions for labels and label profiles should be separated.