### PR TITLE
Fix formatting: Use literal '->' in CDATA context

### DIFF
--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -7164,8 +7164,8 @@ Exampletown</target>
 Element 2
 Element 3
 
-Element 1 -&gt; Element 1.1
-Element 1 -&gt; Element 1.2]]></target>
+Element 1 -> Element 1.1
+Element 1 -> Element 1.2]]></target>
       </segment>
     </unit>
     <unit id="TWSqPFi" name="entity.mass_creation.btn">


### PR DESCRIPTION
This fixes the broken format of the mass creation placeholder text in the demo instance.
I also copy-pasted this in crowdin, so the changes won't get reset later.