### PR TITLE
Autofocus fields

### DIFF
--- a/assets/controllers/elements/collection_type_controller.js
+++ b/assets/controllers/elements/collection_type_controller.js
@@ -79,9 +79,13 @@ export default class extends Controller {
         //Afterwards return the newly created row
         if(targetTable.tBodies[0]) {
             targetTable.tBodies[0].insertAdjacentHTML('beforeend', newElementStr);
+            var fields = targetTable.tBodies[0].querySelectorAll("input[type=number]");
+            fields[fields.length - 1].focus();
             return targetTable.tBodies[0].lastElementChild;
         } else { //Otherwise just insert it
             targetTable.insertAdjacentHTML('beforeend', newElementStr);
+            var fields = targetTable.querySelectorAll("input[type=number]");
+            fields[fields.length - 1].focus();
             return targetTable.lastElementChild;
         }
     }

--- a/assets/controllers/pages/part_withdraw_modal_controller.js
+++ b/assets/controllers/pages/part_withdraw_modal_controller.js
@@ -5,6 +5,7 @@ export default class extends Controller
 {
     connect() {
         this.element.addEventListener('show.bs.modal', event => this._handleModalOpen(event));
+        this.element.addEventListener('shown.bs.modal', event => this._handleModalShown(event));
     }
 
     _handleModalOpen(event) {
@@ -60,5 +61,9 @@ export default class extends Controller
         } else { //Every other action is limited to the amount of parts in the lot
             amountInput.setAttribute('max', lotAmount);
         }
+    }
+
+    _handleModalShown(event) {
+        this.element.querySelector('input[name="amount"]').focus();
     }
 }

--- a/src/Form/AdminPages/BaseEntityAdminForm.php
+++ b/src/Form/AdminPages/BaseEntityAdminForm.php
@@ -71,7 +71,7 @@ class BaseEntityAdminForm extends AbstractType
                 'label' => 'name.label',
                 'attr' => [
                     'placeholder' => 'part.name.placeholder',
-                    'autofocus' => true,
+                    'autofocus' => $is_new,
                 ],
                 'disabled' => !$this->security->isGranted($is_new ? 'create' : 'edit', $entity),
             ]);

--- a/src/Form/AdminPages/BaseEntityAdminForm.php
+++ b/src/Form/AdminPages/BaseEntityAdminForm.php
@@ -71,6 +71,7 @@ class BaseEntityAdminForm extends AbstractType
                 'label' => 'name.label',
                 'attr' => [
                     'placeholder' => 'part.name.placeholder',
+                    'autofocus' => true,
                 ],
                 'disabled' => !$this->security->isGranted($is_new ? 'create' : 'edit', $entity),
             ]);

--- a/src/Form/Part/PartBaseType.php
+++ b/src/Form/Part/PartBaseType.php
@@ -115,7 +115,7 @@ class PartBaseType extends AbstractType
                 'label' => 'part.edit.name',
                 'attr' => [
                     'placeholder' => 'part.edit.name.placeholder',
-                    'autofocus' => true,
+                    'autofocus' => $new_part,
                 ],
             ])
             ->add('description', RichTextEditorType::class, [

--- a/src/Form/Part/PartBaseType.php
+++ b/src/Form/Part/PartBaseType.php
@@ -115,6 +115,7 @@ class PartBaseType extends AbstractType
                 'label' => 'part.edit.name',
                 'attr' => [
                     'placeholder' => 'part.edit.name.placeholder',
+                    'autofocus' => true,
                 ],
             ])
             ->add('description', RichTextEditorType::class, [


### PR DESCRIPTION
Fixes #1157.
- Focus `name` field on all new entity editors
- Focus `amount` on add/withdraw modal
- Focus first `number` type input on any newly added CollectionType table row
(debatable and slightly buggy - focuses `Max` field in parameters...)
- Nothing for Project BOM yet; could be useful there too

It would be even more favorable if the user could configure if they want to use autofocus and/or for which fields/dialogs it should be enabled. I read that autofocus can cause issues with accessibility, especially when using screenreaders. Unfortunately I have no experience in that area :/