### PR TITLE
Add Quick Apply and batch update to bulk info provider import

### DIFF
--- a/assets/controllers/bulk_import_controller.js
+++ b/assets/controllers/bulk_import_controller.js
@@ -3,14 +3,16 @@ import { generateCsrfHeaders } from "./csrf_protection_controller"
 
 export default class extends Controller {
     static targets = ["progressBar", "progressText"]
-    static values = { 
+    static values = {
         jobId: Number,
         partId: Number,
         researchUrl: String,
         researchAllUrl: String,
         markCompletedUrl: String,
         markSkippedUrl: String,
-        markPendingUrl: String
+        markPendingUrl: String,
+        quickApplyUrl: String,
+        quickApplyAllUrl: String
     }
 
     connect() {
@@ -318,6 +320,94 @@ export default class extends Controller {
                 spinner.style.display = 'none'
             }
             button.disabled = false
+        }
+    }
+
+    async quickApply(event) {
+        event.preventDefault()
+        event.stopPropagation()
+
+        const partId = event.currentTarget.dataset.partId
+        const providerKey = event.currentTarget.dataset.providerKey
+        const providerId = event.currentTarget.dataset.providerId
+        const button = event.currentTarget
+        const originalHtml = button.innerHTML
+
+        button.disabled = true
+        button.innerHTML = '<span class="spinner-border spinner-border-sm"></span> Applying...'
+
+        try {
+            const url = this.quickApplyUrlValue.replace('__PART_ID__', partId)
+            const data = await this.fetchWithErrorHandling(url, {
+                method: 'POST',
+                body: JSON.stringify({ providerKey, providerId })
+            }, 60000)
+
+            if (data.success) {
+                this.updateProgressDisplay(data)
+                this.showSuccessMessage(data.message || 'Part updated successfully')
+                sessionStorage.setItem('bulkImportScrollPosition', window.scrollY.toString())
+                window.location.reload()
+            } else {
+                this.showErrorMessage(data.error || 'Quick apply failed')
+                button.innerHTML = originalHtml
+                button.disabled = false
+            }
+        } catch (error) {
+            console.error('Error in quick apply:', error)
+            this.showErrorMessage(error.message || 'Quick apply failed')
+            button.innerHTML = originalHtml
+            button.disabled = false
+        }
+    }
+
+    async quickApplyAll(event) {
+        event.preventDefault()
+        event.stopPropagation()
+
+        if (!confirm('This will apply the top search result to all pending parts without individual review. Continue?')) {
+            return
+        }
+
+        const button = event.currentTarget
+        const spinner = document.getElementById('quick-apply-all-spinner')
+        const originalHtml = button.innerHTML
+
+        button.disabled = true
+        if (spinner) {
+            spinner.style.display = 'inline-block'
+        }
+
+        try {
+            const data = await this.fetchWithErrorHandling(this.quickApplyAllUrlValue, {
+                method: 'POST'
+            }, 300000)
+
+            if (data.success) {
+                this.updateProgressDisplay(data)
+
+                let message = data.message || 'Bulk apply completed'
+                if (data.errors && data.errors.length > 0) {
+                    message += '\nErrors:\n' + data.errors.join('\n')
+                }
+
+                this.showSuccessMessage(message)
+                sessionStorage.setItem('bulkImportScrollPosition', window.scrollY.toString())
+                window.location.reload()
+            } else {
+                this.showErrorMessage(data.error || 'Bulk apply failed')
+                button.innerHTML = originalHtml
+                button.disabled = false
+            }
+        } catch (error) {
+            console.error('Error in quick apply all:', error)
+            this.showErrorMessage(error.message || 'Bulk apply failed')
+            button.innerHTML = originalHtml
+            button.disabled = false
+        } finally {
+            if (spinner) {
+                spinner.style.display = 'none'
+            }
         }
     }
 

--- a/assets/controllers/bulk_import_controller.js
+++ b/assets/controllers/bulk_import_controller.js
@@ -121,13 +121,11 @@ export default class extends Controller {
 
     async markSkipped(event) {
         const partId = event.currentTarget.dataset.partId
-        const reason = prompt('Reason for skipping (optional):') || ''
-        
+
         try {
             const url = this.markSkippedUrlValue.replace('__PART_ID__', partId)
             const data = await this.fetchWithErrorHandling(url, {
-                method: 'POST',
-                body: JSON.stringify({ reason })
+                method: 'POST'
             })
             
             if (data.success) {

--- a/assets/controllers/field_mapping_controller.js
+++ b/assets/controllers/field_mapping_controller.js
@@ -70,6 +70,13 @@ export default class extends Controller {
             newFieldSelect.addEventListener('change', this.updateFieldOptions.bind(this))
         }
 
+        // Auto-increment priority based on existing mappings
+        const nextPriority = this.getNextPriority()
+        const priorityInput = newRow.querySelector('input[name*="[priority]"]')
+        if (priorityInput) {
+            priorityInput.value = nextPriority
+        }
+
         this.updateFieldOptions()
         this.updateAddButtonState()
     }
@@ -117,6 +124,18 @@ export default class extends Controller {
                 this.addButtonTarget.title = ''
             }
         }
+    }
+
+    getNextPriority() {
+        const priorityInputs = this.tbodyTarget.querySelectorAll('input[name*="[priority]"]')
+        let maxPriority = 0
+        priorityInputs.forEach(input => {
+            const val = parseInt(input.value, 10)
+            if (!isNaN(val) && val > maxPriority) {
+                maxPriority = val
+            }
+        })
+        return Math.min(maxPriority + 1, 10)
     }
 
     handleFormSubmit(event) {

--- a/src/Controller/BulkInfoProviderImportController.php
+++ b/src/Controller/BulkInfoProviderImportController.php
@@ -576,6 +576,13 @@ class BulkInfoProviderImportController extends AbstractController
             $providerPart = $infoRetriever->dtoToPart($dto);
             $partMerger->merge($part, $providerPart);
 
+            //Persist part manufacturer and supplier if they are new, to avoid issues with detached entities during merge
+            //Do not footprints here, as it might pollute the database with unwanted formatting footprints from the provider,
+            $this->entityManager->persist($part->getManufacturer());
+            foreach ($part->getOrderdetails() as $orderdetail) {
+                $this->entityManager->persist($orderdetail->getSupplier());
+            }
+
             try {
                 $this->entityManager->flush();
             } catch (ORMInvalidArgumentException $exception) {

--- a/src/Controller/BulkInfoProviderImportController.php
+++ b/src/Controller/BulkInfoProviderImportController.php
@@ -547,7 +547,7 @@ class BulkInfoProviderImportController extends AbstractController
         $this->denyAccessUnlessGranted('edit', $part);
 
         // Get provider key/id from request body, or fall back to top search result
-        $body = json_decode($request->getContent(), true) ?? [];
+        $body = $request->toArray();
         $providerKey = $body['providerKey'] ?? null;
         $providerId = $body['providerId'] ?? null;
 

--- a/src/Controller/BulkInfoProviderImportController.php
+++ b/src/Controller/BulkInfoProviderImportController.php
@@ -36,6 +36,7 @@ use App\Services\InfoProviderSystem\DTOs\BulkSearchPartResultsDTO;
 use App\Services\InfoProviderSystem\DTOs\BulkSearchResponseDTO;
 use App\Services\InfoProviderSystem\PartInfoRetriever;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\ORMInvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -539,6 +540,7 @@ class BulkInfoProviderImportController extends AbstractController
             return $this->createErrorResponse('Job not found or access denied', 404, ['job_id' => $jobId]);
         }
 
+        /** @var Part $part */
         $part = $this->entityManager->getRepository(Part::class)->find($partId);
         if (!$part) {
             return $this->createErrorResponse('Part not found', 404, ['part_id' => $partId]);
@@ -574,13 +576,23 @@ class BulkInfoProviderImportController extends AbstractController
             $providerPart = $infoRetriever->dtoToPart($dto);
             $partMerger->merge($part, $providerPart);
 
-            $this->entityManager->flush();
+            try {
+                $this->entityManager->flush();
+            } catch (ORMInvalidArgumentException $exception) {
+                if (str_contains($exception->getMessage(), 'not configured to cascade persist operations')) {
+                    throw new \RuntimeException('Failed to persist merged part, as it would create new datastructures! Review the provider data by yourself.');
+                }
+
+                throw $exception; // Re-throw if it's a different ORM error
+            }
 
             $job->markPartAsCompleted($partId);
             if ($job->isAllPartsCompleted() && !$job->isCompleted()) {
                 $job->markAsCompleted();
             }
+
             $this->entityManager->flush();
+
 
             return $this->json([
                 'success' => true,
@@ -594,6 +606,8 @@ class BulkInfoProviderImportController extends AbstractController
                 'job_completed' => $job->isCompleted(),
             ]);
         } catch (\Exception $e) {
+            $this->logger->error($e);
+
             return $this->createErrorResponse(
                 'Quick apply failed: ' . $e->getMessage(),
                 500,

--- a/src/Controller/BulkInfoProviderImportController.php
+++ b/src/Controller/BulkInfoProviderImportController.php
@@ -303,9 +303,23 @@ class BulkInfoProviderImportController extends AbstractController
             }
         }
 
+        // Refetch after cleanup and split into active vs finished
+        $allJobs = $this->entityManager->getRepository(BulkInfoProviderImportJob::class)
+            ->findBy([], ['createdAt' => 'DESC']);
+
+        $activeJobs = [];
+        $finishedJobs = [];
+        foreach ($allJobs as $job) {
+            if ($job->isCompleted() || $job->isFailed() || $job->isStopped()) {
+                $finishedJobs[] = $job;
+            } else {
+                $activeJobs[] = $job;
+            }
+        }
+
         return $this->render('info_providers/bulk_import/manage.html.twig', [
-            'jobs' => $this->entityManager->getRepository(BulkInfoProviderImportJob::class)
-                ->findBy([], ['createdAt' => 'DESC']) // Refetch after cleanup
+            'active_jobs' => $activeJobs,
+            'finished_jobs' => $finishedJobs,
         ]);
     }
 

--- a/src/Controller/BulkInfoProviderImportController.php
+++ b/src/Controller/BulkInfoProviderImportController.php
@@ -29,10 +29,12 @@ use App\Entity\Parts\Part;
 use App\Entity\Parts\Supplier;
 use App\Entity\UserSystem\User;
 use App\Form\InfoProviderSystem\GlobalFieldMappingType;
+use App\Services\EntityMergers\Mergers\PartMerger;
 use App\Services\InfoProviderSystem\BulkInfoProviderService;
 use App\Services\InfoProviderSystem\DTOs\BulkSearchFieldMappingDTO;
 use App\Services\InfoProviderSystem\DTOs\BulkSearchPartResultsDTO;
 use App\Services\InfoProviderSystem\DTOs\BulkSearchResponseDTO;
+use App\Services\InfoProviderSystem\PartInfoRetriever;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -513,6 +515,171 @@ class BulkInfoProviderImportController extends AbstractController
                 ]
             );
         }
+    }
+
+    #[Route('/job/{jobId}/part/{partId}/quick-apply', name: 'bulk_info_provider_quick_apply', methods: ['POST'])]
+    public function quickApply(
+        int $jobId,
+        int $partId,
+        Request $request,
+        PartInfoRetriever $infoRetriever,
+        PartMerger $partMerger
+    ): JsonResponse {
+        $job = $this->validateJobAccess($jobId);
+        if (!$job) {
+            return $this->createErrorResponse('Job not found or access denied', 404, ['job_id' => $jobId]);
+        }
+
+        $part = $this->entityManager->getRepository(Part::class)->find($partId);
+        if (!$part) {
+            return $this->createErrorResponse('Part not found', 404, ['part_id' => $partId]);
+        }
+
+        $this->denyAccessUnlessGranted('edit', $part);
+
+        // Get provider key/id from request body, or fall back to top search result
+        $body = json_decode($request->getContent(), true) ?? [];
+        $providerKey = $body['providerKey'] ?? null;
+        $providerId = $body['providerId'] ?? null;
+
+        if (!$providerKey || !$providerId) {
+            $searchResults = $job->getSearchResults($this->entityManager);
+            foreach ($searchResults->partResults as $partResult) {
+                if ($partResult->part->getId() === $partId) {
+                    $sorted = $partResult->getResultsSortedByPriority();
+                    if (!empty($sorted)) {
+                        $providerKey = $sorted[0]->searchResult->provider_key;
+                        $providerId = $sorted[0]->searchResult->provider_id;
+                    }
+                    break;
+                }
+            }
+        }
+
+        if (!$providerKey || !$providerId) {
+            return $this->createErrorResponse('No search result available for this part', 400, ['part_id' => $partId]);
+        }
+
+        try {
+            $dto = $infoRetriever->getDetails($providerKey, $providerId);
+            $providerPart = $infoRetriever->dtoToPart($dto);
+            $partMerger->merge($part, $providerPart);
+
+            $this->entityManager->flush();
+
+            $job->markPartAsCompleted($partId);
+            if ($job->isAllPartsCompleted() && !$job->isCompleted()) {
+                $job->markAsCompleted();
+            }
+            $this->entityManager->flush();
+
+            return $this->json([
+                'success' => true,
+                'message' => sprintf('Applied provider data to "%s"', $part->getName()),
+                'part_id' => $partId,
+                'provider_key' => $providerKey,
+                'provider_id' => $providerId,
+                'progress' => $job->getProgressPercentage(),
+                'completed_count' => $job->getCompletedPartsCount(),
+                'total_count' => $job->getPartCount(),
+                'job_completed' => $job->isCompleted(),
+            ]);
+        } catch (\Exception $e) {
+            return $this->createErrorResponse(
+                'Quick apply failed: ' . $e->getMessage(),
+                500,
+                ['job_id' => $jobId, 'part_id' => $partId, 'exception' => $e->getMessage()]
+            );
+        }
+    }
+
+    #[Route('/job/{jobId}/quick-apply-all', name: 'bulk_info_provider_quick_apply_all', methods: ['POST'])]
+    public function quickApplyAll(
+        int $jobId,
+        PartInfoRetriever $infoRetriever,
+        PartMerger $partMerger
+    ): JsonResponse {
+        set_time_limit(600);
+
+        $job = $this->validateJobAccess($jobId);
+        if (!$job) {
+            return $this->createErrorResponse('Job not found or access denied', 404, ['job_id' => $jobId]);
+        }
+
+        $searchResults = $job->getSearchResults($this->entityManager);
+        $applied = 0;
+        $failed = 0;
+        $noResults = 0;
+        $errors = [];
+
+        foreach ($job->getJobParts() as $jobPart) {
+            if ($jobPart->isCompleted() || $jobPart->isSkipped()) {
+                continue;
+            }
+
+            $part = $jobPart->getPart();
+
+            if (!$this->isGranted('edit', $part)) {
+                $errors[] = sprintf('No edit permission for "%s"', $part->getName());
+                $failed++;
+                continue;
+            }
+
+            // Find top search result for this part
+            $providerKey = null;
+            $providerId = null;
+            foreach ($searchResults->partResults as $partResult) {
+                if ($partResult->part->getId() === $part->getId()) {
+                    $sorted = $partResult->getResultsSortedByPriority();
+                    if (!empty($sorted)) {
+                        $providerKey = $sorted[0]->searchResult->provider_key;
+                        $providerId = $sorted[0]->searchResult->provider_id;
+                    }
+                    break;
+                }
+            }
+
+            if (!$providerKey || !$providerId) {
+                $noResults++;
+                continue;
+            }
+
+            try {
+                $dto = $infoRetriever->getDetails($providerKey, $providerId);
+                $providerPart = $infoRetriever->dtoToPart($dto);
+                $partMerger->merge($part, $providerPart);
+                $this->entityManager->flush();
+
+                $job->markPartAsCompleted($part->getId());
+                $applied++;
+            } catch (\Exception $e) {
+                $this->logger->error('Quick apply failed for part', [
+                    'part_id' => $part->getId(),
+                    'part_name' => $part->getName(),
+                    'error' => $e->getMessage(),
+                ]);
+                $errors[] = sprintf('Failed for "%s": %s', $part->getName(), $e->getMessage());
+                $failed++;
+            }
+        }
+
+        if ($job->isAllPartsCompleted() && !$job->isCompleted()) {
+            $job->markAsCompleted();
+        }
+        $this->entityManager->flush();
+
+        return $this->json([
+            'success' => true,
+            'applied' => $applied,
+            'failed' => $failed,
+            'no_results' => $noResults,
+            'errors' => $errors,
+            'message' => sprintf('Applied to %d parts, %d failed, %d had no results', $applied, $failed, $noResults),
+            'progress' => $job->getProgressPercentage(),
+            'completed_count' => $job->getCompletedPartsCount(),
+            'total_count' => $job->getPartCount(),
+            'job_completed' => $job->isCompleted(),
+        ]);
     }
 
     #[Route('/job/{jobId}/research-all', name: 'bulk_info_provider_research_all', methods: ['POST'])]

--- a/src/Controller/BulkInfoProviderImportController.php
+++ b/src/Controller/BulkInfoProviderImportController.php
@@ -482,7 +482,7 @@ class BulkInfoProviderImportController extends AbstractController
             $this->updatePartSearchResults($job, $searchResultsDto[0] ?? null);
 
             // Prefetch details if requested
-            if ($prefetchDetails && $searchResultsDto !== null) {
+            if ($prefetchDetails) {
                 $this->bulkService->prefetchDetailsForResults($searchResultsDto);
             }
 

--- a/src/Controller/BulkInfoProviderImportController.php
+++ b/src/Controller/BulkInfoProviderImportController.php
@@ -282,8 +282,8 @@ class BulkInfoProviderImportController extends AbstractController
                 $updatedJobs = true;
             }
 
-            // Mark jobs with no results for deletion (failed searches)
-            if ($job->getResultCount() === 0 && $job->isInProgress()) {
+            // Mark jobs with no results for deletion (failed searches or stale pending)
+            if ($job->getResultCount() === 0 && ($job->isInProgress() || $job->isPending())) {
                 $jobsToDelete[] = $job;
             }
         }

--- a/src/Controller/BulkInfoProviderImportController.php
+++ b/src/Controller/BulkInfoProviderImportController.php
@@ -68,6 +68,10 @@ class BulkInfoProviderImportController extends AbstractController
     {
         $dtos = [];
         foreach ($fieldMappings as $mapping) {
+            // Skip entries where field is null/empty (e.g. user added a row but didn't select a field)
+            if (empty($mapping['field'])) {
+                continue;
+            }
             $dtos[] = new BulkSearchFieldMappingDTO(field: $mapping['field'], providers: $mapping['providers'], priority: $mapping['priority'] ?? 1);
         }
         return $dtos;
@@ -472,16 +476,7 @@ class BulkInfoProviderImportController extends AbstractController
             $fieldMappingDtos = $job->getFieldMappings();
             $prefetchDetails = $job->isPrefetchDetails();
 
-            try {
-                $searchResultsDto = $this->bulkService->performBulkSearch([$part], $fieldMappingDtos, $prefetchDetails);
-            } catch (\Exception $searchException) {
-                // Handle "no search results found" as a normal case, not an error
-                if (str_contains($searchException->getMessage(), 'No search results found')) {
-                    $searchResultsDto = null;
-                } else {
-                    throw $searchException;
-                }
-            }
+            $searchResultsDto = $this->bulkService->performBulkSearch([$part], $fieldMappingDtos, $prefetchDetails);
 
             // Update the job's search results for this specific part efficiently
             $this->updatePartSearchResults($job, $searchResultsDto[0] ?? null);

--- a/src/Services/InfoProviderSystem/BulkInfoProviderService.php
+++ b/src/Services/InfoProviderSystem/BulkInfoProviderService.php
@@ -46,7 +46,6 @@ final class BulkInfoProviderService
         }
 
         $partResults = [];
-        $hasAnyResults = false;
 
         // Group providers by batch capability
         $batchProviders = [];
@@ -88,7 +87,6 @@ final class BulkInfoProviderService
             );
 
             if (!empty($allResults)) {
-                $hasAnyResults = true;
                 $searchResults = $this->formatSearchResults($allResults);
             }
 
@@ -97,10 +95,6 @@ final class BulkInfoProviderService
                 searchResults: $searchResults,
                 errors: []
             );
-        }
-
-        if (!$hasAnyResults) {
-            throw new \RuntimeException('No search results found for any of the selected parts');
         }
 
         $response = new BulkSearchResponseDTO($partResults);

--- a/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/LCSCProvider.php
@@ -396,6 +396,7 @@ class LCSCProvider implements BatchInfoProviderInterface, URLHandlerInfoProvider
         // Now collect all results (like .then() in JavaScript)
         foreach ($responses as $keyword => $response) {
             try {
+                $keyword = (string) $keyword;
                 $arr = $response->toArray(); // This waits for the response
                 $results[$keyword] = $this->processSearchResponse($arr, $keyword);
             } catch (\Exception $e) {

--- a/templates/info_providers/bulk_import/manage.html.twig
+++ b/templates/info_providers/bulk_import/manage.html.twig
@@ -22,103 +22,143 @@
             </p>
         </div>
 
-        {% if jobs is not empty %}
-            <div class="table-responsive">
-                <table class="table table-striped">
-                    <thead>
-                    <tr>
-                        <th>{% trans %}info_providers.bulk_import.job_name{% endtrans %}</th>
-                        <th>{% trans %}info_providers.bulk_import.parts_count{% endtrans %}</th>
-                        <th>{% trans %}info_providers.bulk_import.results_count{% endtrans %}</th>
-                        <th>{% trans %}info_providers.bulk_import.progress{% endtrans %}</th>
-                        <th>{% trans %}info_providers.bulk_import.status{% endtrans %}</th>
-                        <th>{% trans %}info_providers.bulk_import.created_by{% endtrans %}</th>
-                        <th>{% trans %}info_providers.bulk_import.created_at{% endtrans %}</th>
-                        <th>{% trans %}info_providers.bulk_import.completed_at{% endtrans %}</th>
-                        <th>{% trans %}info_providers.bulk_import.action.label{% endtrans %}</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for job in jobs %}
-                        <tr>
-                            <td>
-                                <strong>{{ job.displayNameKey|trans(job.displayNameParams) }} - {{ job.formattedTimestamp }}</strong>
-                                {% if job.isInProgress %}
-                                    <span class="badge bg-info ms-2">Active</span>
-                                {% endif %}
-                            </td>
-                            <td>{{ job.partCount }}</td>
-                            <td>{{ job.resultCount }}</td>
-                            <td>
-                                <div class="d-flex align-items-center">
-                                    <div class="progress me-2" style="width: 80px; height: 12px;">
-                                        <div class="progress-bar {% if job.isCompleted %}bg-success{% elseif job.isFailed %}bg-danger{% else %}bg-info{% endif %}"
-                                             role="progressbar"
-                                             style="width: {{ job.progressPercentage }}%"
-                                             aria-valuenow="{{ job.progressPercentage }}"
-                                             aria-valuemin="0" aria-valuemax="100">
-                                        </div>
-                                    </div>
-                                    <small class="text-muted">{{ job.progressPercentage }}%</small>
-                                </div>
-                                <small class="text-muted">
-                                    {% trans with {'%current%': job.completedPartsCount + job.skippedPartsCount, '%total%': job.partCount} %}info_providers.bulk_import.progress_label{% endtrans %}
-                                </small>
-                            </td>
-                            <td>
-                                {% if job.isPending %}
-                                    <span class="badge bg-warning">{% trans %}info_providers.bulk_import.status.pending{% endtrans %}</span>
-                                {% elseif job.isInProgress %}
-                                    <span class="badge bg-info">{% trans %}info_providers.bulk_import.status.in_progress{% endtrans %}</span>
-                                {% elseif job.isCompleted %}
-                                    <span class="badge bg-success">{% trans %}info_providers.bulk_import.status.completed{% endtrans %}</span>
-                                {% elseif job.isStopped %}
-                                    <span class="badge bg-secondary">{% trans %}info_providers.bulk_import.status.stopped{% endtrans %}</span>
-                                {% elseif job.isFailed %}
-                                    <span class="badge bg-danger">{% trans %}info_providers.bulk_import.status.failed{% endtrans %}</span>
-                                {% endif %}
-                            </td>
-                            <td>{{ job.createdBy.fullName(true) }}</td>
-                            <td>{{ job.createdAt|format_datetime('short') }}</td>
-                            <td>
-                                {% if job.completedAt %}
-                                    {{ job.completedAt|format_datetime('short') }}
-                                {% else %}
-                                    <span class="text-muted">-</span>
-                                {% endif %}
-                            </td>
-                            <td>
-                                <div class="btn-group btn-group-sm" role="group">
-                                    {% if job.isInProgress or job.isCompleted or job.isStopped %}
-                                        <a href="{{ path('bulk_info_provider_step2', {'jobId': job.id}) }}" class="btn btn-primary">
-                                            <i class="fas fa-eye"></i> {% trans %}info_providers.bulk_import.view_results{% endtrans %}
-                                        </a>
-                                    {% endif %}
-                                    {% if job.canBeStopped %}
-                                        <button type="button" class="btn btn-warning" data-action="click->bulk-job-manage#stopJob" data-job-id="{{ job.id }}">
-                                            <i class="fas fa-stop"></i> {% trans %}info_providers.bulk_import.action.stop{% endtrans %}
-                                        </button>
-                                    {% endif %}
-                                    {% if job.isCompleted or job.isFailed or job.isStopped %}
-                                        <button type="button" class="btn btn-danger" data-action="click->bulk-job-manage#deleteJob" data-job-id="{{ job.id }}">
-                                            <i class="fas fa-trash"></i> {% trans %}info_providers.bulk_import.action.delete{% endtrans %}
-                                        </button>
-                                    {% endif %}
-                                </div>
-                            </td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        {% else %}
+        {% if active_jobs is empty and finished_jobs is empty %}
             <div class="alert alert-info" role="alert">
                 <i class="fas fa-info-circle"></i>
                 {% trans %}info_providers.bulk_import.no_jobs_found{% endtrans %}<br>
                 {% trans %}info_providers.bulk_import.create_first_job{% endtrans %}
             </div>
+        {% else %}
+            {# Active Jobs #}
+            {% if active_jobs is not empty %}
+                <h5 class="mb-3">
+                    <i class="fas fa-spinner fa-pulse me-1"></i> {% trans %}info_providers.bulk_import.active_jobs{% endtrans %}
+                    <span class="badge bg-primary">{{ active_jobs|length }}</span>
+                </h5>
+                <div class="table-responsive mb-4">
+                    <table class="table table-striped">
+                        <thead>
+                        <tr>
+                            <th>{% trans %}info_providers.bulk_import.job_name{% endtrans %}</th>
+                            <th>{% trans %}info_providers.bulk_import.parts_count{% endtrans %}</th>
+                            <th>{% trans %}info_providers.bulk_import.results_count{% endtrans %}</th>
+                            <th>{% trans %}info_providers.bulk_import.progress{% endtrans %}</th>
+                            <th>{% trans %}info_providers.bulk_import.status{% endtrans %}</th>
+                            <th>{% trans %}info_providers.bulk_import.created_by{% endtrans %}</th>
+                            <th>{% trans %}info_providers.bulk_import.created_at{% endtrans %}</th>
+                            <th>{% trans %}info_providers.bulk_import.action.label{% endtrans %}</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for job in active_jobs %}
+                            {{ _self.job_row(job) }}
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% endif %}
+
+            {# Finished Jobs (History) #}
+            {% if finished_jobs is not empty %}
+                <h5 class="mb-3">
+                    <i class="fas fa-history me-1"></i> {% trans %}info_providers.bulk_import.finished_jobs{% endtrans %}
+                    <span class="badge bg-secondary">{{ finished_jobs|length }}</span>
+                </h5>
+                <div class="table-responsive">
+                    <table class="table table-striped">
+                        <thead>
+                        <tr>
+                            <th>{% trans %}info_providers.bulk_import.job_name{% endtrans %}</th>
+                            <th>{% trans %}info_providers.bulk_import.parts_count{% endtrans %}</th>
+                            <th>{% trans %}info_providers.bulk_import.results_count{% endtrans %}</th>
+                            <th>{% trans %}info_providers.bulk_import.progress{% endtrans %}</th>
+                            <th>{% trans %}info_providers.bulk_import.status{% endtrans %}</th>
+                            <th>{% trans %}info_providers.bulk_import.created_by{% endtrans %}</th>
+                            <th>{% trans %}info_providers.bulk_import.created_at{% endtrans %}</th>
+                            <th>{% trans %}info_providers.bulk_import.completed_at{% endtrans %}</th>
+                            <th>{% trans %}info_providers.bulk_import.action.label{% endtrans %}</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for job in finished_jobs %}
+                            {{ _self.job_row(job, true) }}
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% endif %}
         {% endif %}
 
     </div>
 
 {% endblock %}
+
+{% macro job_row(job, showCompletedAt) %}
+    {% set showCompletedAt = showCompletedAt|default(false) %}
+    <tr>
+        <td>
+            <strong>{{ job.displayNameKey|trans(job.displayNameParams) }} - {{ job.formattedTimestamp }}</strong>
+        </td>
+        <td>{{ job.partCount }}</td>
+        <td>{{ job.resultCount }}</td>
+        <td>
+            <div class="d-flex align-items-center">
+                <div class="progress me-2" style="width: 80px; height: 12px;">
+                    <div class="progress-bar {% if job.isCompleted %}bg-success{% elseif job.isFailed %}bg-danger{% else %}bg-info{% endif %}"
+                         role="progressbar"
+                         style="width: {{ job.progressPercentage }}%"
+                         aria-valuenow="{{ job.progressPercentage }}"
+                         aria-valuemin="0" aria-valuemax="100">
+                    </div>
+                </div>
+                <small class="text-muted">{{ job.progressPercentage }}%</small>
+            </div>
+            <small class="text-muted">
+                {% trans with {'%current%': job.completedPartsCount + job.skippedPartsCount, '%total%': job.partCount} %}info_providers.bulk_import.progress_label{% endtrans %}
+            </small>
+        </td>
+        <td>
+            {% if job.isPending %}
+                <span class="badge bg-warning">{% trans %}info_providers.bulk_import.status.pending{% endtrans %}</span>
+            {% elseif job.isInProgress %}
+                <span class="badge bg-info">{% trans %}info_providers.bulk_import.status.in_progress{% endtrans %}</span>
+            {% elseif job.isCompleted %}
+                <span class="badge bg-success">{% trans %}info_providers.bulk_import.status.completed{% endtrans %}</span>
+            {% elseif job.isStopped %}
+                <span class="badge bg-secondary">{% trans %}info_providers.bulk_import.status.stopped{% endtrans %}</span>
+            {% elseif job.isFailed %}
+                <span class="badge bg-danger">{% trans %}info_providers.bulk_import.status.failed{% endtrans %}</span>
+            {% endif %}
+        </td>
+        <td>{{ job.createdBy.fullName(true) }}</td>
+        <td>{{ job.createdAt|format_datetime('short') }}</td>
+        {% if showCompletedAt %}
+            <td>
+                {% if job.completedAt %}
+                    {{ job.completedAt|format_datetime('short') }}
+                {% else %}
+                    <span class="text-muted">-</span>
+                {% endif %}
+            </td>
+        {% endif %}
+        <td>
+            <div class="btn-group btn-group-sm" role="group">
+                {% if job.isInProgress or job.isCompleted or job.isStopped %}
+                    <a href="{{ path('bulk_info_provider_step2', {'jobId': job.id}) }}" class="btn btn-primary">
+                        <i class="fas fa-eye"></i> {% trans %}info_providers.bulk_import.view_results{% endtrans %}
+                    </a>
+                {% endif %}
+                {% if job.canBeStopped %}
+                    <button type="button" class="btn btn-warning" data-action="click->bulk-job-manage#stopJob" data-job-id="{{ job.id }}">
+                        <i class="fas fa-stop"></i> {% trans %}info_providers.bulk_import.action.stop{% endtrans %}
+                    </button>
+                {% endif %}
+                {% if job.isCompleted or job.isFailed or job.isStopped %}
+                    <button type="button" class="btn btn-danger" data-action="click->bulk-job-manage#deleteJob" data-job-id="{{ job.id }}">
+                        <i class="fas fa-trash"></i> {% trans %}info_providers.bulk_import.action.delete{% endtrans %}
+                    </button>
+                {% endif %}
+            </div>
+        </td>
+    </tr>
+{% endmacro %}

--- a/templates/info_providers/bulk_import/manage.html.twig
+++ b/templates/info_providers/bulk_import/manage.html.twig
@@ -32,7 +32,7 @@
             {# Active Jobs #}
             {% if active_jobs is not empty %}
                 <h5 class="mb-3">
-                    <i class="fas fa-spinner fa-pulse me-1"></i> {% trans %}info_providers.bulk_import.active_jobs{% endtrans %}
+                    <i class="fas fa-tasks me-1"></i> {% trans %}info_providers.bulk_import.active_jobs{% endtrans %}
                     <span class="badge bg-primary">{{ active_jobs|length }}</span>
                 </h5>
                 <div class="table-responsive mb-4">

--- a/templates/info_providers/bulk_import/manage.html.twig
+++ b/templates/info_providers/bulk_import/manage.html.twig
@@ -97,7 +97,8 @@
     {% set showCompletedAt = showCompletedAt|default(false) %}
     <tr>
         <td>
-            <strong>{{ job.displayNameKey|trans(job.displayNameParams) }} - {{ job.formattedTimestamp }}</strong>
+            <strong>#{{ job.id }} - {{ job.displayNameKey|trans(job.displayNameParams) }}</strong>
+            <br><small class="text-muted">{{ job.formattedTimestamp }}</small>
         </td>
         <td>{{ job.partCount }}</td>
         <td>{{ job.resultCount }}</td>

--- a/templates/info_providers/bulk_import/manage.html.twig
+++ b/templates/info_providers/bulk_import/manage.html.twig
@@ -35,27 +35,7 @@
                     <i class="fas fa-tasks me-1"></i> {% trans %}info_providers.bulk_import.active_jobs{% endtrans %}
                     <span class="badge bg-primary">{{ active_jobs|length }}</span>
                 </h5>
-                <div class="table-responsive mb-4">
-                    <table class="table table-striped">
-                        <thead>
-                        <tr>
-                            <th>{% trans %}info_providers.bulk_import.job_name{% endtrans %}</th>
-                            <th>{% trans %}info_providers.bulk_import.parts_count{% endtrans %}</th>
-                            <th>{% trans %}info_providers.bulk_import.results_count{% endtrans %}</th>
-                            <th>{% trans %}info_providers.bulk_import.progress{% endtrans %}</th>
-                            <th>{% trans %}info_providers.bulk_import.status{% endtrans %}</th>
-                            <th>{% trans %}info_providers.bulk_import.created_by{% endtrans %}</th>
-                            <th>{% trans %}info_providers.bulk_import.created_at{% endtrans %}</th>
-                            <th>{% trans %}info_providers.bulk_import.action.label{% endtrans %}</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for job in active_jobs %}
-                            {{ _self.job_row(job) }}
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
+                {{ _self.job_table(active_jobs, false) }}
             {% endif %}
 
             {# Finished Jobs (History) #}
@@ -64,34 +44,40 @@
                     <i class="fas fa-history me-1"></i> {% trans %}info_providers.bulk_import.finished_jobs{% endtrans %}
                     <span class="badge bg-secondary">{{ finished_jobs|length }}</span>
                 </h5>
-                <div class="table-responsive">
-                    <table class="table table-striped">
-                        <thead>
-                        <tr>
-                            <th>{% trans %}info_providers.bulk_import.job_name{% endtrans %}</th>
-                            <th>{% trans %}info_providers.bulk_import.parts_count{% endtrans %}</th>
-                            <th>{% trans %}info_providers.bulk_import.results_count{% endtrans %}</th>
-                            <th>{% trans %}info_providers.bulk_import.progress{% endtrans %}</th>
-                            <th>{% trans %}info_providers.bulk_import.status{% endtrans %}</th>
-                            <th>{% trans %}info_providers.bulk_import.created_by{% endtrans %}</th>
-                            <th>{% trans %}info_providers.bulk_import.created_at{% endtrans %}</th>
-                            <th>{% trans %}info_providers.bulk_import.completed_at{% endtrans %}</th>
-                            <th>{% trans %}info_providers.bulk_import.action.label{% endtrans %}</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for job in finished_jobs %}
-                            {{ _self.job_row(job, true) }}
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
+                {{ _self.job_table(finished_jobs, true) }}
             {% endif %}
         {% endif %}
 
     </div>
 
 {% endblock %}
+
+{% macro job_table(jobs, showCompletedAt) %}
+    <div class="table-responsive">
+        <table class="table table-striped">
+            <thead>
+            <tr>
+                <th>{% trans %}info_providers.bulk_import.job_name{% endtrans %}</th>
+                <th>{% trans %}info_providers.bulk_import.parts_count{% endtrans %}</th>
+                <th>{% trans %}info_providers.bulk_import.results_count{% endtrans %}</th>
+                <th>{% trans %}info_providers.bulk_import.progress{% endtrans %}</th>
+                <th>{% trans %}info_providers.bulk_import.status{% endtrans %}</th>
+                <th>{% trans %}info_providers.bulk_import.created_by{% endtrans %}</th>
+                <th>{% trans %}info_providers.bulk_import.created_at{% endtrans %}</th>
+                {% if showCompletedAt %}
+                    <th>{% trans %}info_providers.bulk_import.completed_at{% endtrans %}</th>
+                {% endif %}
+                <th>{% trans %}info_providers.bulk_import.action.label{% endtrans %}</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for job in jobs %}
+                {{ _self.job_row(job, showCompletedAt) }}
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endmacro %}
 
 {% macro job_row(job, showCompletedAt) %}
     {% set showCompletedAt = showCompletedAt|default(false) %}

--- a/templates/info_providers/bulk_import/step2.html.twig
+++ b/templates/info_providers/bulk_import/step2.html.twig
@@ -220,8 +220,12 @@
                                                  class="hoverpic" style="max-width: 35px;" {{ stimulus_controller('elements/hoverpic') }}>
                                         </td>
                                         <td>
-                                            {% set nameMatch = dto.name is not null and part.name is not null and dto.name|lower == part.name|lower %}
-                                            {% set mpnMatch = dto.mpn is not null and part.manufacturerProductNumber is not null and dto.mpn|lower == part.manufacturerProductNumber|lower %}
+                                            {# Check for matches against source keyword (what was searched) #}
+                                            {% set sourceKw = result.sourceKeyword|default('')|lower %}
+                                            {% set nameMatch = sourceKw is not empty and dto.name is not null and dto.name|lower == sourceKw %}
+                                            {% set mpnMatch = sourceKw is not empty and dto.mpn is not null and dto.mpn|lower == sourceKw %}
+                                            {% set spnMatch = sourceKw is not empty and dto.provider_id is not null and dto.provider_id|lower == sourceKw %}
+                                            {% set anyMatch = nameMatch or mpnMatch or spnMatch %}
                                             {% if dto.provider_url is not null %}
                                                 <a href="{{ dto.provider_url }}" target="_blank" rel="noopener"{% if nameMatch %} class="fw-bold"{% endif %}>{{ dto.name }}</a>
                                             {% else %}
@@ -231,7 +235,7 @@
                                                 <span class="badge bg-success ms-1" title="{% trans %}info_providers.bulk_import.exact_match{% endtrans %}"><i class="fas fa-check-circle"></i></span>
                                             {% endif %}
                                             {% if dto.mpn is not null %}
-                                                <br><small{% if mpnMatch %} class="fw-bold text-success"{% else %} class="text-muted"{% endif %}>{{ dto.mpn }}</small>
+                                                <br><small{% if mpnMatch %} class="fw-bold text-success"{% endif %}>{{ dto.mpn }}</small>
                                                 {% if mpnMatch %}
                                                     <span class="badge bg-success ms-1" style="font-size: 0.65em;" title="{% trans %}info_providers.bulk_import.mpn_match{% endtrans %}">MPN <i class="fas fa-check-circle"></i></span>
                                                 {% endif %}
@@ -241,10 +245,17 @@
                                         <td>{{ dto.manufacturer ?? '' }}</td>
                                         <td>
                                             {{ info_provider_label(dto.provider_key)|default(dto.provider_key) }}
-                                            <br><small class="text-muted">{{ dto.provider_id }}</small>
+                                            <br><small{% if spnMatch %} class="fw-bold text-success"{% endif %}>{{ dto.provider_id }}</small>
+                                            {% if spnMatch %}
+                                                <span class="badge bg-success ms-1" style="font-size: 0.65em;" title="{% trans %}info_providers.bulk_import.spn_match{% endtrans %}">SPN <i class="fas fa-check-circle"></i></span>
+                                            {% endif %}
                                         </td>
                                         <td>
-                                            <span class="badge bg-info">{{ result.sourceField ?? 'unknown' }}</span>
+                                            {% if anyMatch %}
+                                                <span class="badge bg-success">{% trans %}info_providers.bulk_import.match{% endtrans %}</span>
+                                            {% else %}
+                                                <span class="badge bg-info">{{ result.sourceField ?? 'unknown' }}</span>
+                                            {% endif %}
                                             {% if result.sourceKeyword %}
                                                 <br><small>{{ result.sourceKeyword }}</small>
                                             {% endif %}

--- a/templates/info_providers/bulk_import/step2.html.twig
+++ b/templates/info_providers/bulk_import/step2.html.twig
@@ -216,8 +216,11 @@
                                     {% set isTopResult = loop.first %}
                                     <tr{% if isTopResult and not isCompleted %} class="table-success"{% endif %}>
                                         <td>
-                                            <img src="{{ dto.preview_image_url }}" data-thumbnail="{{ dto.preview_image_url }}"
-                                                 class="hoverpic" style="max-width: 35px;" {{ stimulus_controller('elements/hoverpic') }}>
+                                            {% if dto.preview_image_url %}
+                                                <img src="{{ dto.preview_image_url }}" data-thumbnail="{{ dto.preview_image_url }}"
+                                                     class="hoverpic" style="max-width: 35px;" {{ stimulus_controller('elements/hoverpic') }}
+                                                     onerror="this.style.display='none'">
+                                            {% endif %}
                                         </td>
                                         <td>
                                             {# Check for matches against source keyword (what was searched) #}
@@ -257,7 +260,7 @@
                                                 <span class="badge bg-info">{{ result.sourceField ?? 'unknown' }}</span>
                                             {% endif %}
                                             {% if result.sourceKeyword %}
-                                                <br><small>{{ result.sourceKeyword }}</small>
+                                                <br><small{% if anyMatch %} class="fw-bold text-success"{% endif %}>{{ result.sourceKeyword }}</small>
                                             {% endif %}
                                         </td>
                                         <td>

--- a/templates/info_providers/bulk_import/step2.html.twig
+++ b/templates/info_providers/bulk_import/step2.html.twig
@@ -9,7 +9,7 @@
 
 {% block card_title %}
     <i class="fas fa-search"></i> {% trans %}info_providers.bulk_import.step2.title{% endtrans %}
-    <span class="badge bg-secondary">{{ job.displayNameKey|trans(job.displayNameParams) }} - {{ job.formattedTimestamp }}</span>
+    <span class="badge bg-secondary">#{{ job.id }} - {{ job.displayNameKey|trans(job.displayNameParams) }}</span>
 {% endblock %}
 
 {% block card_content %}
@@ -44,7 +44,7 @@
 }) }}>
     <div class="d-flex justify-content-between align-items-center mb-3">
         <div>
-            <h5 class="mb-1">{{ job.displayNameKey|trans(job.displayNameParams) }} - {{ job.formattedTimestamp }}</h5>
+            <h5 class="mb-1">#{{ job.id }} - {{ job.displayNameKey|trans(job.displayNameParams) }}</h5>
             <small class="text-muted">
                 {{ job.partCount }} {% trans %}info_providers.bulk_import.parts{% endtrans %} •
                 {{ job.resultCount }} {% trans %}info_providers.bulk_import.results{% endtrans %} •

--- a/templates/info_providers/bulk_import/step2.html.twig
+++ b/templates/info_providers/bulk_import/step2.html.twig
@@ -20,7 +20,9 @@
     'researchAllUrl': path('bulk_info_provider_research_all', {'jobId': job.id}),
     'markCompletedUrl': path('bulk_info_provider_mark_completed', {'jobId': job.id, 'partId': '__PART_ID__'}),
     'markSkippedUrl': path('bulk_info_provider_mark_skipped', {'jobId': job.id, 'partId': '__PART_ID__'}),
-    'markPendingUrl': path('bulk_info_provider_mark_pending', {'jobId': job.id, 'partId': '__PART_ID__'})
+    'markPendingUrl': path('bulk_info_provider_mark_pending', {'jobId': job.id, 'partId': '__PART_ID__'}),
+    'quickApplyUrl': path('bulk_info_provider_quick_apply', {'jobId': job.id, 'partId': '__PART_ID__'}),
+    'quickApplyAllUrl': path('bulk_info_provider_quick_apply_all', {'jobId': job.id})
 }) }}>
     <div class="d-flex justify-content-between align-items-center mb-3">
         <div>
@@ -94,6 +96,13 @@
                             id="research-all-btn">
                         <span class="spinner-border spinner-border-sm me-1" style="display: none;" id="research-all-spinner"></span>
                         <i class="fas fa-search"></i> {% trans %}info_providers.bulk_import.research.all_pending{% endtrans %}
+                    </button>
+                    <button type="button" class="btn btn-success btn-sm"
+                            data-action="click->bulk-import#quickApplyAll"
+                            id="quick-apply-all-btn"
+                            title="{% trans %}info_providers.bulk_import.quick_apply_all.tooltip{% endtrans %}">
+                        <span class="spinner-border spinner-border-sm me-1" style="display: none;" id="quick-apply-all-spinner"></span>
+                        <i class="fas fa-bolt"></i> {% trans %}info_providers.bulk_import.quick_apply_all{% endtrans %}
                     </button>
                 </div>
             </div>
@@ -214,6 +223,16 @@
                                         </td>
                                         <td>
                                             <div class="btn-group-vertical btn-group-sm" role="group">
+                                                {% if not isCompleted %}
+                                                    <button type="button" class="btn btn-success"
+                                                            data-action="click->bulk-import#quickApply"
+                                                            data-part-id="{{ part.id }}"
+                                                            data-provider-key="{{ dto.provider_key }}"
+                                                            data-provider-id="{{ dto.provider_id }}"
+                                                            title="{% trans %}info_providers.bulk_import.quick_apply.tooltip{% endtrans %}">
+                                                        <i class="fas fa-bolt"></i> {% trans %}info_providers.bulk_import.quick_apply{% endtrans %}
+                                                    </button>
+                                                {% endif %}
                                                 {% set updateHref = path('info_providers_update_part',
                                                     {'id': part.id, 'providerKey': dto.provider_key, 'providerId': dto.provider_id}) ~ '?jobId=' ~ job.id %}
                                                 <a class="btn btn-primary{% if isCompleted %} disabled{% endif %}" href="{% if not isCompleted %}{{ updateHref }}{% else %}#{% endif %}"{% if isCompleted %} aria-disabled="true"{% endif %}>

--- a/templates/info_providers/bulk_import/step2.html.twig
+++ b/templates/info_providers/bulk_import/step2.html.twig
@@ -266,7 +266,7 @@
                                         <td>
                                             <div class="btn-group-vertical btn-group-sm" role="group">
                                                 {% if not isCompleted %}
-                                                    <button type="button" class="btn btn-success{% if not isTopResult %} btn-outline-success{% endif %}"
+                                                    <button type="button" class="btn {% if not isTopResult %} btn-outline-success{% else %}btn-success{% endif %}"
                                                             data-action="click->bulk-import#quickApply"
                                                             data-part-id="{{ part.id }}"
                                                             data-provider-key="{{ dto.provider_key }}"

--- a/templates/info_providers/bulk_import/step2.html.twig
+++ b/templates/info_providers/bulk_import/step2.html.twig
@@ -220,13 +220,21 @@
                                                  class="hoverpic" style="max-width: 35px;" {{ stimulus_controller('elements/hoverpic') }}>
                                         </td>
                                         <td>
+                                            {% set nameMatch = dto.name is not null and part.name is not null and dto.name|lower == part.name|lower %}
+                                            {% set mpnMatch = dto.mpn is not null and part.manufacturerProductNumber is not null and dto.mpn|lower == part.manufacturerProductNumber|lower %}
                                             {% if dto.provider_url is not null %}
-                                                <a href="{{ dto.provider_url }}" target="_blank" rel="noopener">{{ dto.name }}</a>
+                                                <a href="{{ dto.provider_url }}" target="_blank" rel="noopener"{% if nameMatch %} class="fw-bold"{% endif %}>{{ dto.name }}</a>
                                             {% else %}
-                                                {{ dto.name }}
+                                                <span{% if nameMatch %} class="fw-bold"{% endif %}>{{ dto.name }}</span>
+                                            {% endif %}
+                                            {% if nameMatch %}
+                                                <span class="badge bg-success ms-1" title="{% trans %}info_providers.bulk_import.exact_match{% endtrans %}"><i class="fas fa-check-circle"></i></span>
                                             {% endif %}
                                             {% if dto.mpn is not null %}
-                                                <br><small class="text-muted">{{ dto.mpn }}</small>
+                                                <br><small{% if mpnMatch %} class="fw-bold text-success"{% else %} class="text-muted"{% endif %}>{{ dto.mpn }}</small>
+                                                {% if mpnMatch %}
+                                                    <span class="badge bg-success ms-1" style="font-size: 0.65em;" title="{% trans %}info_providers.bulk_import.mpn_match{% endtrans %}">MPN <i class="fas fa-check-circle"></i></span>
+                                                {% endif %}
                                             {% endif %}
                                         </td>
                                         <td>{{ dto.description }}</td>
@@ -238,8 +246,8 @@
                                         <td>
                                             <span class="badge bg-info">{{ result.sourceField ?? 'unknown' }}</span>
                                             {% if result.sourceKeyword %}
-                                                <br><small class="text-muted">{{ result.sourceKeyword }}</small>
-                            {% endif %}
+                                                <br><small>{{ result.sourceKeyword }}</small>
+                                            {% endif %}
                                         </td>
                                         <td>
                                             <div class="btn-group-vertical btn-group-sm" role="group">

--- a/templates/info_providers/bulk_import/step2.html.twig
+++ b/templates/info_providers/bulk_import/step2.html.twig
@@ -208,11 +208,13 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                {% for result in part_result.searchResults %}
+                                {% set sortedResults = part_result.resultsSortedByPriority %}
+                                {% for result in sortedResults %}
                                     {# @var result \App\Services\InfoProviderSystem\DTOs\BulkSearchPartResultDTO #}
                                     {% set dto = result.searchResult %}
                                     {% set localPart = result.localPart %}
-                                    <tr>
+                                    {% set isTopResult = loop.first %}
+                                    <tr{% if isTopResult and not isCompleted %} class="table-success"{% endif %}>
                                         <td>
                                             <img src="{{ dto.preview_image_url }}" data-thumbnail="{{ dto.preview_image_url }}"
                                                  class="hoverpic" style="max-width: 35px;" {{ stimulus_controller('elements/hoverpic') }}>
@@ -242,13 +244,14 @@
                                         <td>
                                             <div class="btn-group-vertical btn-group-sm" role="group">
                                                 {% if not isCompleted %}
-                                                    <button type="button" class="btn btn-success"
+                                                    <button type="button" class="btn btn-success{% if not isTopResult %} btn-outline-success{% endif %}"
                                                             data-action="click->bulk-import#quickApply"
                                                             data-part-id="{{ part.id }}"
                                                             data-provider-key="{{ dto.provider_key }}"
                                                             data-provider-id="{{ dto.provider_id }}"
                                                             title="{% trans %}info_providers.bulk_import.quick_apply.tooltip{% endtrans %}">
                                                         <i class="fas fa-bolt"></i> {% trans %}info_providers.bulk_import.quick_apply{% endtrans %}
+                                                        {% if isTopResult %}<span class="badge bg-light text-success ms-1">{% trans %}info_providers.bulk_import.recommended{% endtrans %}</span>{% endif %}
                                                     </button>
                                                 {% endif %}
                                                 {% set updateHref = path('info_providers_update_part',

--- a/templates/info_providers/bulk_import/step2.html.twig
+++ b/templates/info_providers/bulk_import/step2.html.twig
@@ -14,6 +14,24 @@
 
 {% block card_content %}
 
+    <!-- Navigation -->
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <a href="{{ path('bulk_info_provider_manage') }}" class="btn btn-outline-secondary btn-sm">
+            <i class="fas fa-arrow-left"></i> {% trans %}info_providers.bulk_import.back_to_jobs{% endtrans %}
+        </a>
+        <a href="{{ path('parts_show_all') }}" class="btn btn-outline-primary btn-sm">
+            <i class="fas fa-list"></i> {% trans %}info_providers.bulk_import.back_to_parts{% endtrans %}
+        </a>
+    </div>
+
+    {% if job.isCompleted %}
+        <div class="alert alert-success mb-3" role="alert">
+            <i class="fas fa-check-circle"></i>
+            <strong>{% trans %}info_providers.bulk_import.job_completed{% endtrans %}</strong>
+            {% trans %}info_providers.bulk_import.job_completed.description{% endtrans %}
+        </div>
+    {% endif %}
+
 <div {{ stimulus_controller('bulk-import', {
     'jobId': job.id,
     'researchUrl': path('bulk_info_provider_research_part', {'jobId': job.id, 'partId': '__PART_ID__'}),

--- a/tests/Controller/BulkInfoProviderImportControllerTest.php
+++ b/tests/Controller/BulkInfoProviderImportControllerTest.php
@@ -1169,4 +1169,684 @@ final class BulkInfoProviderImportControllerTest extends WebTestCase
         $entityManager->remove($job);
         $entityManager->flush();
     }
+
+    /**
+     * Helper to create a job with search results for testing.
+     */
+    private function createJobWithSearchResults(object $entityManager, object $user, array $parts, string $status = 'in_progress'): BulkInfoProviderImportJob
+    {
+        $job = new BulkInfoProviderImportJob();
+        $job->setCreatedBy($user);
+        foreach ($parts as $part) {
+            $job->addPart($part);
+        }
+
+        $statusEnum = match ($status) {
+            'pending' => BulkImportJobStatus::PENDING,
+            'completed' => BulkImportJobStatus::COMPLETED,
+            'stopped' => BulkImportJobStatus::STOPPED,
+            default => BulkImportJobStatus::IN_PROGRESS,
+        };
+        $job->setStatus($statusEnum);
+
+        // Create search results with a result per part
+        $partResults = [];
+        foreach ($parts as $part) {
+            $partResults[] = new BulkSearchPartResultsDTO(
+                part: $part,
+                searchResults: [
+                    new BulkSearchPartResultDTO(
+                        searchResult: new SearchResultDTO(
+                            provider_key: 'test_provider',
+                            provider_id: 'TEST_' . $part->getId(),
+                            name: $part->getName() ?? 'Test Part',
+                            description: 'Test description',
+                            manufacturer: 'Test Mfg',
+                            mpn: 'MPN-' . $part->getId(),
+                            provider_url: 'https://example.com/' . $part->getId(),
+                            preview_image_url: null,
+                        ),
+                        sourceField: 'mpn',
+                        sourceKeyword: $part->getName() ?? 'test',
+                        localPart: null,
+                    ),
+                ]
+            );
+        }
+
+        $job->setSearchResults(new BulkSearchResponseDTO($partResults));
+        $entityManager->persist($job);
+        $entityManager->flush();
+
+        return $job;
+    }
+
+    private function cleanupJob(object $entityManager, int $jobId): void
+    {
+        $entityManager->clear();
+        $persistedJob = $entityManager->find(BulkInfoProviderImportJob::class, $jobId);
+        if ($persistedJob) {
+            $entityManager->remove($persistedJob);
+            $entityManager->flush();
+        }
+    }
+
+    public function testDeleteCompletedJob(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        $job = $this->createJobWithSearchResults($entityManager, $user, $parts, 'completed');
+        $jobId = $job->getId();
+
+        $client->request('DELETE', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/delete');
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertTrue($response['success']);
+
+        // Verify job was deleted
+        $entityManager->clear();
+        $this->assertNull($entityManager->find(BulkInfoProviderImportJob::class, $jobId));
+    }
+
+    public function testDeleteActiveJobFails(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        $job = $this->createJobWithSearchResults($entityManager, $user, $parts, 'in_progress');
+        $jobId = $job->getId();
+
+        $client->request('DELETE', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/delete');
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $this->cleanupJob($entityManager, $jobId);
+    }
+
+    public function testDeleteNonExistentJob(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $client->request('DELETE', '/en/tools/bulk_info_provider_import/job/999999/delete');
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testStopInProgressJob(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        $job = $this->createJobWithSearchResults($entityManager, $user, $parts, 'in_progress');
+        $jobId = $job->getId();
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/stop');
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertTrue($response['success']);
+
+        // Verify job is stopped
+        $entityManager->clear();
+        $stoppedJob = $entityManager->find(BulkInfoProviderImportJob::class, $jobId);
+        $this->assertTrue($stoppedJob->isStopped());
+
+        $entityManager->remove($stoppedJob);
+        $entityManager->flush();
+    }
+
+    public function testStopNonExistentJob(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/999999/stop');
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testMarkPartCompleted(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        $job = $this->createJobWithSearchResults($entityManager, $user, $parts);
+        $jobId = $job->getId();
+        $partId = $parts[0]->getId();
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/part/' . $partId . '/mark-completed');
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertTrue($response['success']);
+        $this->assertEquals(1, $response['completed_count']);
+        $this->assertTrue($response['job_completed']);
+
+        $this->cleanupJob($entityManager, $jobId);
+    }
+
+    public function testMarkPartSkipped(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        $job = $this->createJobWithSearchResults($entityManager, $user, $parts);
+        $jobId = $job->getId();
+        $partId = $parts[0]->getId();
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/part/' . $partId . '/mark-skipped', [
+            'reason' => 'Not needed'
+        ]);
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertTrue($response['success']);
+        $this->assertEquals(1, $response['skipped_count']);
+
+        $this->cleanupJob($entityManager, $jobId);
+    }
+
+    public function testMarkPartPending(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        $job = $this->createJobWithSearchResults($entityManager, $user, $parts);
+        $jobId = $job->getId();
+        $partId = $parts[0]->getId();
+
+        // First mark as completed
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/part/' . $partId . '/mark-completed');
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        // Then mark as pending again
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/part/' . $partId . '/mark-pending');
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertTrue($response['success']);
+        $this->assertEquals(0, $response['completed_count']);
+
+        $this->cleanupJob($entityManager, $jobId);
+    }
+
+    public function testMarkPartCompletedNonExistentJob(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/999999/part/1/mark-completed');
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testQuickApplyWithValidJob(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        $job = $this->createJobWithSearchResults($entityManager, $user, $parts);
+        $jobId = $job->getId();
+        $partId = $parts[0]->getId();
+
+        // Quick apply will fail because test_provider doesn't exist, but it exercises the code path
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/part/' . $partId . '/quick-apply', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['providerKey' => 'test_provider', 'providerId' => 'TEST_1']));
+
+        // Will get 500 because test_provider doesn't exist, which exercises the catch block
+        $this->assertResponseStatusCodeSame(Response::HTTP_INTERNAL_SERVER_ERROR);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertFalse($response['success']);
+        $this->assertStringContainsString('Quick apply failed', $response['error']);
+
+        $this->cleanupJob($entityManager, $jobId);
+    }
+
+    public function testQuickApplyFallsBackToTopResult(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        $job = $this->createJobWithSearchResults($entityManager, $user, $parts);
+        $jobId = $job->getId();
+        $partId = $parts[0]->getId();
+
+        // No providerKey/providerId in body - should fall back to top search result
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/part/' . $partId . '/quick-apply', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], '{}');
+
+        // Will get 500 because test_provider doesn't exist, but exercises the fallback code path
+        $this->assertResponseStatusCodeSame(Response::HTTP_INTERNAL_SERVER_ERROR);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertStringContainsString('Quick apply failed', $response['error']);
+
+        $this->cleanupJob($entityManager, $jobId);
+    }
+
+    public function testQuickApplyWithNoSearchResults(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        // Create job with empty search results
+        $job = new BulkInfoProviderImportJob();
+        $job->setCreatedBy($user);
+        foreach ($parts as $part) {
+            $job->addPart($part);
+        }
+        $job->setStatus(BulkImportJobStatus::IN_PROGRESS);
+        $job->setSearchResults(new BulkSearchResponseDTO([
+            new BulkSearchPartResultsDTO(part: $parts[0], searchResults: [])
+        ]));
+        $entityManager->persist($job);
+        $entityManager->flush();
+
+        $jobId = $job->getId();
+        $partId = $parts[0]->getId();
+
+        // No provider specified and no search results - should return 400
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/part/' . $partId . '/quick-apply', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], '{}');
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertStringContainsString('No search result available', $response['error']);
+
+        $this->cleanupJob($entityManager, $jobId);
+    }
+
+    public function testQuickApplyNonExistentPart(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        $job = $this->createJobWithSearchResults($entityManager, $user, $parts);
+        $jobId = $job->getId();
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/part/999999/quick-apply');
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+
+        $this->cleanupJob($entityManager, $jobId);
+    }
+
+    public function testQuickApplyAllWithValidJob(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        $job = $this->createJobWithSearchResults($entityManager, $user, $parts);
+        $jobId = $job->getId();
+
+        // Quick apply all - will fail for test_provider but exercises the code path
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/quick-apply-all');
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertTrue($response['success']);
+        // Should have 1 failed (because test_provider doesn't exist)
+        $this->assertEquals(1, $response['failed']);
+        $this->assertNotEmpty($response['errors']);
+
+        $this->cleanupJob($entityManager, $jobId);
+    }
+
+    public function testQuickApplyAllWithNoSearchResults(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        // Create job with empty results
+        $job = new BulkInfoProviderImportJob();
+        $job->setCreatedBy($user);
+        foreach ($parts as $part) {
+            $job->addPart($part);
+        }
+        $job->setStatus(BulkImportJobStatus::IN_PROGRESS);
+        $job->setSearchResults(new BulkSearchResponseDTO([
+            new BulkSearchPartResultsDTO(part: $parts[0], searchResults: [])
+        ]));
+        $entityManager->persist($job);
+        $entityManager->flush();
+
+        $jobId = $job->getId();
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/quick-apply-all');
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertTrue($response['success']);
+        $this->assertEquals(0, $response['applied']);
+        $this->assertEquals(1, $response['no_results']);
+
+        $this->cleanupJob($entityManager, $jobId);
+    }
+
+    public function testQuickApplyAllNonExistentJob(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/999999/quick-apply-all');
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testQuickApplyAllSkipsCompletedParts(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        $job = $this->createJobWithSearchResults($entityManager, $user, $parts);
+        $jobId = $job->getId();
+
+        // Mark the part as completed first
+        $job->markPartAsCompleted($parts[0]->getId());
+        $entityManager->flush();
+
+        // Quick apply all should skip already-completed parts
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/quick-apply-all');
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertEquals(0, $response['applied']);
+        $this->assertEquals(0, $response['failed']);
+        $this->assertEquals(0, $response['no_results']);
+
+        $this->cleanupJob($entityManager, $jobId);
+    }
+
+    public function testDeleteStoppedJob(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        $job = $this->createJobWithSearchResults($entityManager, $user, $parts, 'stopped');
+        $jobId = $job->getId();
+
+        $client->request('DELETE', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/delete');
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertTrue($response['success']);
+
+        $entityManager->clear();
+        $this->assertNull($entityManager->find(BulkInfoProviderImportJob::class, $jobId));
+    }
+
+    public function testManagePageSplitsActiveAndHistory(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        // Create one active and one completed job
+        $activeJob = $this->createJobWithSearchResults($entityManager, $user, $parts, 'in_progress');
+        $completedJob = $this->createJobWithSearchResults($entityManager, $user, $parts, 'completed');
+
+        $client->request('GET', '/en/tools/bulk_info_provider_import/manage');
+        if ($client->getResponse()->isRedirect()) {
+            $client->followRedirect();
+        }
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $content = (string) $client->getResponse()->getContent();
+        $this->assertStringContainsString('Active Jobs', $content);
+        $this->assertStringContainsString('History', $content);
+
+        $this->cleanupJob($entityManager, $activeJob->getId());
+        $this->cleanupJob($entityManager, $completedJob->getId());
+    }
+
+    public function testManagePageCleansUpPendingJobsWithNoResults(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        // Create a pending job with no results (should be cleaned up)
+        $job = new BulkInfoProviderImportJob();
+        $job->setCreatedBy($user);
+        foreach ($parts as $part) {
+            $job->addPart($part);
+        }
+        $job->setStatus(BulkImportJobStatus::PENDING);
+        $job->setSearchResults(new BulkSearchResponseDTO([]));
+        $entityManager->persist($job);
+        $entityManager->flush();
+        $jobId = $job->getId();
+
+        // Visit manage page - should trigger cleanup
+        $client->request('GET', '/en/tools/bulk_info_provider_import/manage');
+        if ($client->getResponse()->isRedirect()) {
+            $client->followRedirect();
+        }
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        // Verify the stale job was cleaned up
+        $entityManager->clear();
+        $this->assertNull($entityManager->find(BulkInfoProviderImportJob::class, $jobId));
+    }
+
+    public function testStep2WithNonExistentJob(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $client->request('GET', '/en/tools/bulk_info_provider_import/step2/999999');
+
+        // Should redirect with error flash
+        $this->assertResponseRedirects();
+    }
+
+    public function testStep2WithOtherUsersJob(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $otherUser = $entityManager->getRepository(User::class)->findOneBy(['name' => 'noread']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$otherUser || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        $job = $this->createJobWithSearchResults($entityManager, $otherUser, $parts);
+        $jobId = $job->getId();
+
+        $client->request('GET', '/en/tools/bulk_info_provider_import/step2/' . $jobId);
+
+        // Should redirect with access denied
+        $this->assertResponseRedirects();
+
+        $this->cleanupJob($entityManager, $jobId);
+    }
+
+    public function testResearchPartNonExistentJob(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/999999/part/1/research');
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testResearchPartNonExistentPart(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        $job = $this->createJobWithSearchResults($entityManager, $user, $parts);
+        $jobId = $job->getId();
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/part/999999/research');
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+
+        $this->cleanupJob($entityManager, $jobId);
+    }
+
+    public function testResearchAllNonExistentJob(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/999999/research-all');
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testResearchAllWithAllPartsCompleted(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        if (!$user || empty($parts)) {
+            $this->markTestSkipped('Required fixtures not found');
+        }
+
+        $job = $this->createJobWithSearchResults($entityManager, $user, $parts);
+        $jobId = $job->getId();
+
+        // Mark all parts as completed
+        foreach ($parts as $part) {
+            $job->markPartAsCompleted($part->getId());
+        }
+        $entityManager->flush();
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $jobId . '/research-all');
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertTrue($response['success']);
+        $this->assertEquals(0, $response['researched_count']);
+
+        $this->cleanupJob($entityManager, $jobId);
+    }
 }

--- a/tests/Controller/BulkInfoProviderImportControllerTest.php
+++ b/tests/Controller/BulkInfoProviderImportControllerTest.php
@@ -1025,13 +1025,9 @@ final class BulkInfoProviderImportControllerTest extends WebTestCase
             new BulkSearchFieldMappingDTO('test_supplier_spn', ['test'], 2)
         ];
 
-        // The service should be able to process the request and throw an exception when no results are found
-        try {
-            $bulkService->performBulkSearch([$part], $fieldMappings, false);
-            $this->fail('Expected RuntimeException to be thrown when no search results are found');
-        } catch (\RuntimeException $e) {
-            $this->assertStringContainsString('No search results found', $e->getMessage());
-        }
+        // The service should return an empty response DTO when no results are found
+        $response = $bulkService->performBulkSearch([$part], $fieldMappings, false);
+        $this->assertFalse($response->hasAnyResults());
     }
 
     public function testBulkInfoProviderServiceBatchProcessing(): void
@@ -1055,13 +1051,9 @@ final class BulkInfoProviderImportControllerTest extends WebTestCase
             new BulkSearchFieldMappingDTO('empty', ['test'], 1)
         ];
 
-        // The service should be able to process the request and throw an exception when no results are found
-        try {
-            $response = $bulkService->performBulkSearch([$part], $fieldMappings, false);
-            $this->fail('Expected RuntimeException to be thrown when no search results are found');
-        } catch (\RuntimeException $e) {
-            $this->assertStringContainsString('No search results found', $e->getMessage());
-        }
+        // The service should return an empty response DTO when no results are found
+        $response = $bulkService->performBulkSearch([$part], $fieldMappings, false);
+        $this->assertFalse($response->hasAnyResults());
     }
 
     public function testBulkInfoProviderServicePrefetchDetails(): void

--- a/tests/Controller/BulkInfoProviderImportControllerTest.php
+++ b/tests/Controller/BulkInfoProviderImportControllerTest.php
@@ -1327,7 +1327,7 @@ final class BulkInfoProviderImportControllerTest extends WebTestCase
         $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
     }
 
-    public function testMarkPartCompleted(): void
+    public function testMarkPartCompletedAutoCompletesJob(): void
     {
         $client = static::createClient();
         $this->loginAsUser($client, 'admin');
@@ -1354,7 +1354,7 @@ final class BulkInfoProviderImportControllerTest extends WebTestCase
         $this->cleanupJob($entityManager, $jobId);
     }
 
-    public function testMarkPartSkipped(): void
+    public function testMarkPartSkippedWithReason(): void
     {
         $client = static::createClient();
         $this->loginAsUser($client, 'admin');
@@ -1382,7 +1382,7 @@ final class BulkInfoProviderImportControllerTest extends WebTestCase
         $this->cleanupJob($entityManager, $jobId);
     }
 
-    public function testMarkPartPending(): void
+    public function testMarkPartPendingAfterCompleted(): void
     {
         $client = static::createClient();
         $this->loginAsUser($client, 'admin');
@@ -1744,7 +1744,7 @@ final class BulkInfoProviderImportControllerTest extends WebTestCase
         $this->assertNull($entityManager->find(BulkInfoProviderImportJob::class, $jobId));
     }
 
-    public function testStep2WithNonExistentJob(): void
+    public function testStep2RedirectsForNonExistentJob(): void
     {
         $client = static::createClient();
         $this->loginAsUser($client, 'admin');

--- a/tests/Controller/BulkInfoProviderImportControllerTest.php
+++ b/tests/Controller/BulkInfoProviderImportControllerTest.php
@@ -589,6 +589,296 @@ final class BulkInfoProviderImportControllerTest extends WebTestCase
         return $parts;
     }
 
+    public function testQuickApplyWithNonExistentJob(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/999999/part/1/quick-apply');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertArrayHasKey('error', $response);
+    }
+
+    public function testQuickApplyWithNonExistentPart(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $userRepository = $entityManager->getRepository(User::class);
+        $user = $userRepository->findOneBy(['name' => 'admin']);
+
+        if (!$user) {
+            $this->markTestSkipped('Admin user not found in fixtures');
+        }
+
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        $job = new BulkInfoProviderImportJob();
+        $job->setCreatedBy($user);
+        foreach ($parts as $part) {
+            $job->addPart($part);
+        }
+        $job->setStatus(BulkImportJobStatus::IN_PROGRESS);
+        $job->setSearchResults(new BulkSearchResponseDTO([]));
+
+        $entityManager->persist($job);
+        $entityManager->flush();
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $job->getId() . '/part/999999/quick-apply');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+
+        // Clean up
+        $entityManager->remove($job);
+        $entityManager->flush();
+    }
+
+    public function testQuickApplyWithNoSearchResults(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $userRepository = $entityManager->getRepository(User::class);
+        $user = $userRepository->findOneBy(['name' => 'admin']);
+
+        if (!$user) {
+            $this->markTestSkipped('Admin user not found in fixtures');
+        }
+
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        $job = new BulkInfoProviderImportJob();
+        $job->setCreatedBy($user);
+        foreach ($parts as $part) {
+            $job->addPart($part);
+        }
+        $job->setStatus(BulkImportJobStatus::IN_PROGRESS);
+        // Empty search results - no provider results for any parts
+        $job->setSearchResults(new BulkSearchResponseDTO([
+            new BulkSearchPartResultsDTO(part: $parts[0], searchResults: [], errors: [])
+        ]));
+
+        $entityManager->persist($job);
+        $entityManager->flush();
+
+        // Quick apply without providing providerKey/providerId and no search results available
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $job->getId() . '/part/1/quick-apply', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertFalse($response['success']);
+
+        // Clean up
+        $entityManager->remove($job);
+        $entityManager->flush();
+    }
+
+    public function testQuickApplyAccessControl(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $userRepository = $entityManager->getRepository(User::class);
+        $admin = $userRepository->findOneBy(['name' => 'admin']);
+        $readonly = $userRepository->findOneBy(['name' => 'noread']);
+
+        if (!$admin || !$readonly) {
+            $this->markTestSkipped('Required test users not found in fixtures');
+        }
+
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        // Create job owned by readonly user
+        $job = new BulkInfoProviderImportJob();
+        $job->setCreatedBy($readonly);
+        foreach ($parts as $part) {
+            $job->addPart($part);
+        }
+        $job->setStatus(BulkImportJobStatus::IN_PROGRESS);
+        $job->setSearchResults(new BulkSearchResponseDTO([]));
+
+        $entityManager->persist($job);
+        $entityManager->flush();
+
+        // Admin tries to quick apply on readonly user's job - should fail
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $job->getId() . '/part/1/quick-apply');
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+
+        // Clean up
+        $jobId = $job->getId();
+        $entityManager->clear();
+        $persistedJob = $entityManager->find(BulkInfoProviderImportJob::class, $jobId);
+        if ($persistedJob) {
+            $entityManager->remove($persistedJob);
+            $entityManager->flush();
+        }
+    }
+
+    public function testQuickApplyAllWithNonExistentJob(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/999999/quick-apply-all');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertArrayHasKey('error', $response);
+    }
+
+    public function testQuickApplyAllWithNoResults(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $userRepository = $entityManager->getRepository(User::class);
+        $user = $userRepository->findOneBy(['name' => 'admin']);
+
+        if (!$user) {
+            $this->markTestSkipped('Admin user not found in fixtures');
+        }
+
+        $parts = $this->getTestParts($entityManager, [1, 2]);
+
+        $job = new BulkInfoProviderImportJob();
+        $job->setCreatedBy($user);
+        foreach ($parts as $part) {
+            $job->addPart($part);
+        }
+        $job->setStatus(BulkImportJobStatus::IN_PROGRESS);
+        // Empty search results for all parts
+        $job->setSearchResults(new BulkSearchResponseDTO([
+            new BulkSearchPartResultsDTO(part: $parts[0], searchResults: [], errors: []),
+            new BulkSearchPartResultsDTO(part: $parts[1], searchResults: [], errors: []),
+        ]));
+
+        $entityManager->persist($job);
+        $entityManager->flush();
+
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $job->getId() . '/quick-apply-all');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertTrue($response['success']);
+        $this->assertEquals(0, $response['applied']);
+        $this->assertEquals(2, $response['no_results']);
+
+        // Clean up
+        $entityManager->remove($job);
+        $entityManager->flush();
+    }
+
+    public function testQuickApplyAllAccessControl(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $userRepository = $entityManager->getRepository(User::class);
+        $readonly = $userRepository->findOneBy(['name' => 'noread']);
+
+        if (!$readonly) {
+            $this->markTestSkipped('Required test users not found in fixtures');
+        }
+
+        $parts = $this->getTestParts($entityManager, [1]);
+
+        $job = new BulkInfoProviderImportJob();
+        $job->setCreatedBy($readonly);
+        foreach ($parts as $part) {
+            $job->addPart($part);
+        }
+        $job->setStatus(BulkImportJobStatus::IN_PROGRESS);
+        $job->setSearchResults(new BulkSearchResponseDTO([]));
+
+        $entityManager->persist($job);
+        $entityManager->flush();
+
+        // Admin tries quick apply all on readonly user's job
+        $client->request('POST', '/en/tools/bulk_info_provider_import/job/' . $job->getId() . '/quick-apply-all');
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+
+        // Clean up
+        $jobId = $job->getId();
+        $entityManager->clear();
+        $persistedJob = $entityManager->find(BulkInfoProviderImportJob::class, $jobId);
+        if ($persistedJob) {
+            $entityManager->remove($persistedJob);
+            $entityManager->flush();
+        }
+    }
+
+    public function testStep2TemplateRenderingWithQuickApplyButtons(): void
+    {
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = static::getContainer()->get('doctrine')->getManager();
+        $partRepository = $entityManager->getRepository(Part::class);
+        $part = $partRepository->find(1);
+
+        if (!$part) {
+            $this->markTestSkipped('Test part with ID 1 not found in fixtures');
+        }
+
+        $userRepository = $entityManager->getRepository(User::class);
+        $user = $userRepository->findOneBy(['name' => 'admin']);
+
+        if (!$user) {
+            $this->markTestSkipped('Admin user not found in fixtures');
+        }
+
+        $job = new BulkInfoProviderImportJob();
+        $job->setCreatedBy($user);
+        $job->addPart($part);
+        $job->setStatus(BulkImportJobStatus::IN_PROGRESS);
+
+        $searchResults = new BulkSearchResponseDTO(partResults: [
+            new BulkSearchPartResultsDTO(part: $part,
+                searchResults: [new BulkSearchPartResultDTO(
+                    searchResult: new SearchResultDTO(provider_key: 'test_provider', provider_id: 'TEST123', name: 'Test Component', description: 'Test description', manufacturer: 'Test Mfg', mpn: 'TEST-MPN', provider_url: 'https://example.com/test', preview_image_url: null),
+                    sourceField: 'mpn',
+                    sourceKeyword: 'TEST-MPN',
+                )]
+            )
+        ]);
+
+        $job->setSearchResults($searchResults);
+
+        $entityManager->persist($job);
+        $entityManager->flush();
+
+        $client->request('GET', '/tools/bulk_info_provider_import/step2/' . $job->getId());
+
+        if ($client->getResponse()->isRedirect()) {
+            $client->followRedirect();
+        }
+
+        self::assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $content = (string) $client->getResponse()->getContent();
+        // Verify quick apply buttons are rendered (Stimulus renders camelCase as kebab-case data attributes)
+        $this->assertStringContainsString('quick-apply-url-value', $content);
+        $this->assertStringContainsString('quick-apply-all-url-value', $content);
+
+        // Clean up
+        $jobId = $job->getId();
+        $entityManager->clear();
+        $jobToRemove = $entityManager->find(BulkInfoProviderImportJob::class, $jobId);
+        if ($jobToRemove) {
+            $entityManager->remove($jobToRemove);
+            $entityManager->flush();
+        }
+    }
+
     public function testStep1Form(): void
     {
         $client = static::createClient();

--- a/tests/Controller/BulkInfoProviderImportControllerTest.php
+++ b/tests/Controller/BulkInfoProviderImportControllerTest.php
@@ -1483,7 +1483,7 @@ final class BulkInfoProviderImportControllerTest extends WebTestCase
         $this->cleanupJob($entityManager, $jobId);
     }
 
-    public function testQuickApplyWithNoSearchResults(): void
+    public function testQuickApplyEmptyResultsReturns400(): void
     {
         $client = static::createClient();
         $this->loginAsUser($client, 'admin');

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -11103,6 +11103,30 @@ Please note, that you can not impersonate a disabled user. If you try you will g
         <target>Update Part</target>
       </segment>
     </unit>
+    <unit id="quick_apply_btn" name="info_providers.bulk_import.quick_apply">
+      <segment state="translated">
+        <source>info_providers.bulk_import.quick_apply</source>
+        <target>Quick Apply</target>
+      </segment>
+    </unit>
+    <unit id="quick_apply_tooltip" name="info_providers.bulk_import.quick_apply.tooltip">
+      <segment state="translated">
+        <source>info_providers.bulk_import.quick_apply.tooltip</source>
+        <target>Apply this provider result to the part without opening the edit form</target>
+      </segment>
+    </unit>
+    <unit id="quick_apply_all_btn" name="info_providers.bulk_import.quick_apply_all">
+      <segment state="translated">
+        <source>info_providers.bulk_import.quick_apply_all</source>
+        <target>Apply All (Top Results)</target>
+      </segment>
+    </unit>
+    <unit id="quick_apply_all_tooltip" name="info_providers.bulk_import.quick_apply_all.tooltip">
+      <segment state="translated">
+        <source>info_providers.bulk_import.quick_apply_all.tooltip</source>
+        <target>Apply the top-ranked search result to all pending parts without individual review</target>
+      </segment>
+    </unit>
     <unit id="e_DDQ2u" name="info_providers.bulk_import.prefetch_details">
       <segment state="translated">
         <source>info_providers.bulk_import.prefetch_details</source>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -11103,91 +11103,91 @@ Please note, that you can not impersonate a disabled user. If you try you will g
         <target>Update Part</target>
       </segment>
     </unit>
-    <unit id="back_to_jobs_btn" name="info_providers.bulk_import.back_to_jobs">
+    <unit id="_sWGLGs" name="info_providers.bulk_import.back_to_jobs">
       <segment state="translated">
         <source>info_providers.bulk_import.back_to_jobs</source>
         <target>Back to Jobs</target>
       </segment>
     </unit>
-    <unit id="back_to_parts_btn" name="info_providers.bulk_import.back_to_parts">
+    <unit id="2DCRx_T" name="info_providers.bulk_import.back_to_parts">
       <segment state="translated">
         <source>info_providers.bulk_import.back_to_parts</source>
         <target>Back to Parts</target>
       </segment>
     </unit>
-    <unit id="job_completed_msg" name="info_providers.bulk_import.job_completed">
+    <unit id="9OAohXg" name="info_providers.bulk_import.job_completed">
       <segment state="translated">
         <source>info_providers.bulk_import.job_completed</source>
         <target>Job completed!</target>
       </segment>
     </unit>
-    <unit id="job_completed_desc" name="info_providers.bulk_import.job_completed.description">
+    <unit id="hwkbU38" name="info_providers.bulk_import.job_completed.description">
       <segment state="translated">
         <source>info_providers.bulk_import.job_completed.description</source>
         <target>All parts have been processed. You can review the results below or navigate back to the parts list.</target>
       </segment>
     </unit>
-    <unit id="recommended_badge" name="info_providers.bulk_import.recommended">
+    <unit id="ahbWfwA" name="info_providers.bulk_import.recommended">
       <segment state="translated">
         <source>info_providers.bulk_import.recommended</source>
         <target>Top</target>
       </segment>
     </unit>
-    <unit id="exact_match_badge" name="info_providers.bulk_import.exact_match">
+    <unit id="tFJOMYX" name="info_providers.bulk_import.exact_match">
       <segment state="translated">
         <source>info_providers.bulk_import.exact_match</source>
         <target>Exact name match</target>
       </segment>
     </unit>
-    <unit id="mpn_match_badge" name="info_providers.bulk_import.mpn_match">
+    <unit id="mBAxdTx" name="info_providers.bulk_import.mpn_match">
       <segment state="translated">
         <source>info_providers.bulk_import.mpn_match</source>
         <target>MPN matches</target>
       </segment>
     </unit>
-    <unit id="active_jobs_header" name="info_providers.bulk_import.active_jobs">
+    <unit id="W1HbYWX" name="info_providers.bulk_import.active_jobs">
       <segment state="translated">
         <source>info_providers.bulk_import.active_jobs</source>
         <target>Active Jobs</target>
       </segment>
     </unit>
-    <unit id="finished_jobs_header" name="info_providers.bulk_import.finished_jobs">
+    <unit id="tZSOzU1" name="info_providers.bulk_import.finished_jobs">
       <segment state="translated">
         <source>info_providers.bulk_import.finished_jobs</source>
         <target>History</target>
       </segment>
     </unit>
-    <unit id="spn_match_badge" name="info_providers.bulk_import.spn_match">
+    <unit id="noEU4s7" name="info_providers.bulk_import.spn_match">
       <segment state="translated">
         <source>info_providers.bulk_import.spn_match</source>
         <target>SPN matches</target>
       </segment>
     </unit>
-    <unit id="match_badge" name="info_providers.bulk_import.match">
+    <unit id="RiHOuLh" name="info_providers.bulk_import.match">
       <segment state="translated">
         <source>info_providers.bulk_import.match</source>
         <target>Match</target>
       </segment>
     </unit>
-    <unit id="quick_apply_btn" name="info_providers.bulk_import.quick_apply">
+    <unit id="UCKGkQ3" name="info_providers.bulk_import.quick_apply">
       <segment state="translated">
         <source>info_providers.bulk_import.quick_apply</source>
         <target>Quick Apply</target>
       </segment>
     </unit>
-    <unit id="quick_apply_tooltip" name="info_providers.bulk_import.quick_apply.tooltip">
+    <unit id="4uMgGbn" name="info_providers.bulk_import.quick_apply.tooltip">
       <segment state="translated">
         <source>info_providers.bulk_import.quick_apply.tooltip</source>
         <target>Apply this provider result to the part without opening the edit form</target>
       </segment>
     </unit>
-    <unit id="quick_apply_all_btn" name="info_providers.bulk_import.quick_apply_all">
+    <unit id="a8kwuvb" name="info_providers.bulk_import.quick_apply_all">
       <segment state="translated">
         <source>info_providers.bulk_import.quick_apply_all</source>
         <target>Apply All (Top Results)</target>
       </segment>
     </unit>
-    <unit id="quick_apply_all_tooltip" name="info_providers.bulk_import.quick_apply_all.tooltip">
+    <unit id=".iZc63I" name="info_providers.bulk_import.quick_apply_all.tooltip">
       <segment state="translated">
         <source>info_providers.bulk_import.quick_apply_all.tooltip</source>
         <target>Apply the top-ranked search result to all pending parts without individual review</target>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -11103,6 +11103,30 @@ Please note, that you can not impersonate a disabled user. If you try you will g
         <target>Update Part</target>
       </segment>
     </unit>
+    <unit id="back_to_jobs_btn" name="info_providers.bulk_import.back_to_jobs">
+      <segment state="translated">
+        <source>info_providers.bulk_import.back_to_jobs</source>
+        <target>Back to Jobs</target>
+      </segment>
+    </unit>
+    <unit id="back_to_parts_btn" name="info_providers.bulk_import.back_to_parts">
+      <segment state="translated">
+        <source>info_providers.bulk_import.back_to_parts</source>
+        <target>Back to Parts</target>
+      </segment>
+    </unit>
+    <unit id="job_completed_msg" name="info_providers.bulk_import.job_completed">
+      <segment state="translated">
+        <source>info_providers.bulk_import.job_completed</source>
+        <target>Job completed!</target>
+      </segment>
+    </unit>
+    <unit id="job_completed_desc" name="info_providers.bulk_import.job_completed.description">
+      <segment state="translated">
+        <source>info_providers.bulk_import.job_completed.description</source>
+        <target>All parts have been processed. You can review the results below or navigate back to the parts list.</target>
+      </segment>
+    </unit>
     <unit id="quick_apply_btn" name="info_providers.bulk_import.quick_apply">
       <segment state="translated">
         <source>info_providers.bulk_import.quick_apply</source>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -11133,6 +11133,30 @@ Please note, that you can not impersonate a disabled user. If you try you will g
         <target>Top</target>
       </segment>
     </unit>
+    <unit id="exact_match_badge" name="info_providers.bulk_import.exact_match">
+      <segment state="translated">
+        <source>info_providers.bulk_import.exact_match</source>
+        <target>Exact name match</target>
+      </segment>
+    </unit>
+    <unit id="mpn_match_badge" name="info_providers.bulk_import.mpn_match">
+      <segment state="translated">
+        <source>info_providers.bulk_import.mpn_match</source>
+        <target>MPN matches</target>
+      </segment>
+    </unit>
+    <unit id="active_jobs_header" name="info_providers.bulk_import.active_jobs">
+      <segment state="translated">
+        <source>info_providers.bulk_import.active_jobs</source>
+        <target>Active Jobs</target>
+      </segment>
+    </unit>
+    <unit id="finished_jobs_header" name="info_providers.bulk_import.finished_jobs">
+      <segment state="translated">
+        <source>info_providers.bulk_import.finished_jobs</source>
+        <target>History</target>
+      </segment>
+    </unit>
     <unit id="quick_apply_btn" name="info_providers.bulk_import.quick_apply">
       <segment state="translated">
         <source>info_providers.bulk_import.quick_apply</source>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -11127,6 +11127,12 @@ Please note, that you can not impersonate a disabled user. If you try you will g
         <target>All parts have been processed. You can review the results below or navigate back to the parts list.</target>
       </segment>
     </unit>
+    <unit id="recommended_badge" name="info_providers.bulk_import.recommended">
+      <segment state="translated">
+        <source>info_providers.bulk_import.recommended</source>
+        <target>Top</target>
+      </segment>
+    </unit>
     <unit id="quick_apply_btn" name="info_providers.bulk_import.quick_apply">
       <segment state="translated">
         <source>info_providers.bulk_import.quick_apply</source>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -11157,6 +11157,18 @@ Please note, that you can not impersonate a disabled user. If you try you will g
         <target>History</target>
       </segment>
     </unit>
+    <unit id="spn_match_badge" name="info_providers.bulk_import.spn_match">
+      <segment state="translated">
+        <source>info_providers.bulk_import.spn_match</source>
+        <target>SPN matches</target>
+      </segment>
+    </unit>
+    <unit id="match_badge" name="info_providers.bulk_import.match">
+      <segment state="translated">
+        <source>info_providers.bulk_import.match</source>
+        <target>Match</target>
+      </segment>
+    </unit>
     <unit id="quick_apply_btn" name="info_providers.bulk_import.quick_apply">
       <segment state="translated">
         <source>info_providers.bulk_import.quick_apply</source>


### PR DESCRIPTION
## Summary

Adds one-click **Quick Apply** buttons and a batch **Apply All (Top Results)** action to the bulk info provider import step 2 page, so users no longer need to open every single component and click save twice to update from provider data.

This was requested by a user: *"For something that should be added is on bulk import to be able to just mass update from provider rather than having to open EVERY single component and click save changes twice, so annoying"*

### Features
- **Quick Apply per result**: AJAX button that fetches provider details and merges them into the part in one click
- **Apply All (Top Results)**: Batch button that applies the top-priority result for every pending part at once
- **Match highlighting**: Green "Match" badge when the source keyword matches the result (MPN, SPN, name)
- **Top result indicator**: First result (highest priority) is highlighted with a green row and "Top" badge
- **Active/History split on manage page**: Active jobs shown at top, completed/stopped jobs in a separate History section
- **Job ID display**: Each job now shows `#ID` for easy identification
- **Navigation buttons**: "Back to Jobs" and "Back to Parts" on the step 2 review page
- **Completion banner**: Clear indication when a job is fully completed
- **Auto-priority for field mappings**: Each new field mapping row auto-increments priority
- **Stale job cleanup**: Pending jobs with 0 results are automatically cleaned up

### Bug fixes
- Fix TypeError in LCSCProvider when keyword is numeric string (cast to string)
- Fix 500 error when field mapping has null field or no search results
- Fix spinning icon on manage page (was using pulse animation that never stopped)
- Fix text visibility issues in dark theme for source field badges
- Remove unexpected "reason for skipping" prompt when clicking Quick Apply

### Screenshots

**Step 2 - Review page with Quick Apply and match highlighting:**
<img width="1578" height="977" alt="Screenshot 2026-03-12 115444" src="https://github.com/user-attachments/assets/2edc20f6-2385-46c7-8226-096651f74d1e" />


**Manage page with Active/History split and job IDs:**
<img width="1908" height="1024" alt="Screenshot 2026-03-12 115518" src="https://github.com/user-attachments/assets/a5377af5-0ae9-4f99-82d4-e3360b6f7ca9" />


## Test plan
- [x] PHPStan: 0 errors on all changed files
- [x] PHPUnit: All new tests pass (8 new test methods, 16+ assertions)
- [x] Manual testing on live server with real LCSC provider data
- [x] Quick Apply on individual parts with single and multiple results
- [x] Apply All (Top Results) batch operation
- [x] Match highlighting for MPN, SPN, and name matches
- [x] Navigation buttons and completion flow
- [x] Active/History job separation on manage page