### PR TITLE
Show total cost for minimum order quantity in price-tier view

### DIFF
--- a/templates/parts/info/_order_infos.html.twig
+++ b/templates/parts/info/_order_infos.html.twig
@@ -46,8 +46,9 @@
                                         {{ detail.MinDiscountQuantity | format_amount(part.partUnit) }}
                                     </td>
                                     <td>
-                                        {{ detail.price | format_money(detail.currency) }} / {{ detail.PriceRelatedQuantity | format_amount(part.partUnit) }}
-                                        {% set tmp = pricedetail_helper.convertMoneyToCurrency(detail.price, detail.currency, app.user.currency ?? null) %}
+                                        {% set total = detail.PricePerUnit(detail.MinDiscountQuantity) %}
+                                        {{ total | format_money(detail.currency) }} / {{ detail.MinDiscountQuantity | format_amount(part.partUnit) }}
+                                        {% set tmp = pricedetail_helper.convertMoneyToCurrency(total, detail.currency, app.user.currency ?? null) %}
                                         {% if detail.currency != (app.user.currency ?? null) and tmp is not null and tmp.GreaterThan(0) %}
                                             <span class="text-muted">({{ tmp | format_money(app.user.currency ?? null) }})</span>
                                         {% endif %}


### PR DESCRIPTION
On the part info → **Shopping information** tab, the "Price" column always rendered as `<stored price> / <price_related_quantity>`. For supplier data imported from LCSC, Mouser, Digikey etc., `price_related_quantity` defaults to `1` and the stored price is the per-unit price — so every row showed something like `$0.0037 / 1`, identical to the adjacent "Unit Price" column and giving no information about what you'd actually pay for the minimum bulk order.

Example (LCSC C86285, 15pF capacitor, sold in min. quantities of 100):

| Min. amount | Price (before) | Price (after) | Unit Price |
|---|---|---|---|
| 100 | $0.0037 / 1 | **$0.37 / 100** | $0.0037 |
| 1000 | $0.0029 / 1 | **$2.90 / 1000** | $0.0029 |
| 3000 | $0.0025 / 1 | **$7.50 / 3000** | $0.0025 |
