### PR TITLE
Parameter parser AWG

### DIFF
--- a/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
+++ b/src/Services/InfoProviderSystem/DTOs/ParameterDTO.php
@@ -94,6 +94,13 @@ readonly class ParameterDTO
 
                 //If both parts have the same unit and both values are numerical, we'll save it as range
                 if ($unit === $unit2 && is_numeric($number) && is_numeric($number2)) {
+                    //If the parameter contains AWG in name or unit and min/max order is "wrong", swap it
+                    if (preg_match('/AWG/', $name . $unit) === 1 && $number > $number2) {
+                        $tmp = $number;
+                        $number = $number2;
+                        $number2 = $tmp;
+                    }
+                    
                     return new self(name: $name, value_text: $value_text2, value_min: (float) $number,
                         value_max: (float) $number2, unit: $unit, symbol: $symbol, group: $group);
                 }

--- a/tests/Services/InfoProviderSystem/DTOs/ParameterDTOTest.php
+++ b/tests/Services/InfoProviderSystem/DTOs/ParameterDTOTest.php
@@ -81,6 +81,16 @@ final class ParameterDTOTest extends TestCase
             'test'
         ];
 
+        //Test inverse AWG range
+        yield [
+            new ParameterDTO('test', value_min: 14, value_max: 22, unit: 'AWG', symbol: 'm', group: 'test'),
+            'test',
+            '22..14',
+            'AWG',
+            'm',
+            'test'
+        ];
+
         //Test ranges with tilde
         yield [
             new ParameterDTO('test', value_min: -1.0, value_max: 2.0, unit: 'kg', symbol: 'm', group: 'test'),


### PR DESCRIPTION
Swaps the min/max AWG values if they are ordered from "small diameter" to "big diameter", i.e. "big number" to "small number".
Fixes #1351.