### PR TITLE
Change part merge behaviour on info provider update

### DIFF
--- a/src/Services/EntityMergers/Mergers/PartMerger.php
+++ b/src/Services/EntityMergers/Mergers/PartMerger.php
@@ -88,9 +88,9 @@ class PartMerger implements EntityMergerInterface
             return $t;
         }, $target, $other, 'manufacturing_status');
 
-        //Merge provider reference
+        //Merge provider reference - always use the most recent provider if set
         $this->useCallback(function (InfoProviderReference $t, InfoProviderReference $o): InfoProviderReference {
-            if (!$t->isProviderCreated() && $o->isProviderCreated()) {
+            if ($o->isProviderCreated()) {
                 return $o;
             }
             return $t;


### PR DESCRIPTION
Fixes #1394
This changes the info provider "tag" if the user updates the part from a different info provider than it was created from, so favoring the more recently queried source by default.