### PR TITLE
Clarify library addition as HTTP in KiCad documentation

### DIFF
--- a/docs/usage/eda_integration.md
+++ b/docs/usage/eda_integration.md
@@ -54,7 +54,7 @@ To connect KiCad with Part-DB do the following steps:
 ```
 4. Replace the `root_url` with the URL of your Part-DB instance plus `/en/kicad-api/`. You can find the right value for this in the Part-DB user settings page under "API endpoints" in the "API tokens" panel.
 5. Replace the `token` field value with the token you have generated in step 1.
-6. Open KiCad and add this created file as a library in the KiCad symbol table under (Preferences --> Manage Symbol Libraries)
+6. Open KiCad and add this created file as a HTTP library in the KiCad symbol table under (Preferences --> Manage Symbol Libraries)
 
 If you then place a new part, the library dialog opens, and you should be able to see the categories and parts from Part-DB.
 


### PR DESCRIPTION
One Word documentation addition to specify adding the Kicad Library file as a HTTP library.