### PR TITLE
Add per-parameter "visible in symbol" flag for KiCad EDA export

### DIFF
--- a/migrations/Version20260713120000.php
+++ b/migrations/Version20260713120000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Migration\AbstractMultiPlatformMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20260713120000 extends AbstractMultiPlatformMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add eda_symbol_visibility nullable boolean column to parameters table (controls the "visible" flag of the exported KiCad field)';
+    }
+
+    public function mySQLUp(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE parameters ADD eda_symbol_visibility TINYINT(1) DEFAULT NULL');
+    }
+
+    public function mySQLDown(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE parameters DROP COLUMN eda_symbol_visibility');
+    }
+
+    public function sqLiteUp(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE parameters ADD COLUMN eda_symbol_visibility BOOLEAN DEFAULT NULL');
+    }
+
+    public function sqLiteDown(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE parameters DROP COLUMN eda_symbol_visibility');
+    }
+
+    public function postgreSQLUp(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE parameters ADD eda_symbol_visibility BOOLEAN DEFAULT NULL');
+    }
+
+    public function postgreSQLDown(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE parameters DROP COLUMN eda_symbol_visibility');
+    }
+}

--- a/src/Entity/Parameters/AbstractParameter.php
+++ b/src/Entity/Parameters/AbstractParameter.php
@@ -180,6 +180,14 @@ abstract class AbstractParameter extends AbstractNamedDBElement implements Uniqu
     protected ?bool $eda_visibility = null;
 
     /**
+     * @var bool|null Whether the exported EDA field should be visible in the schematic symbol
+     *                (sets the KiCad field's "visible" flag). Null means use system default.
+     */
+    #[Groups(['full', 'parameter:read', 'parameter:write', 'import'])]
+    #[ORM\Column(type: Types::BOOLEAN, nullable: true, options: ['default' => null])]
+    protected ?bool $eda_symbol_visibility = null;
+
+    /**
      * Mapping is done in subclasses.
      *
      * @var AbstractDBElement|null the element to which this parameter belongs to
@@ -489,6 +497,21 @@ abstract class AbstractParameter extends AbstractNamedDBElement implements Uniqu
     public function setEdaVisibility(?bool $eda_visibility): self
     {
         $this->eda_visibility = $eda_visibility;
+
+        return $this;
+    }
+
+    public function isEdaSymbolVisibility(): ?bool
+    {
+        return $this->eda_symbol_visibility;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setEdaSymbolVisibility(?bool $eda_symbol_visibility): self
+    {
+        $this->eda_symbol_visibility = $eda_symbol_visibility;
 
         return $this;
     }

--- a/src/Form/ParameterType.php
+++ b/src/Form/ParameterType.php
@@ -156,6 +156,11 @@ class ParameterType extends AbstractType
                 'label' => false,
                 'required' => false,
             ]);
+
+            $builder->add('eda_symbol_visibility', TriStateCheckboxType::class, [
+                'label' => false,
+                'required' => false,
+            ]);
         }
     }
 

--- a/src/Services/EDA/KiCadHelper.php
+++ b/src/Services/EDA/KiCadHelper.php
@@ -341,7 +341,9 @@ class KiCadHelper
                 $fieldName = $parameter->getName();
                 //Don't overwrite hardcoded fields
                 if (!isset($result['fields'][$fieldName])) {
-                    $result['fields'][$fieldName] = $this->createField($parameter->getFormattedValue());
+                    //Whether the field should be visible in the schematic symbol (explicit, or system default when null)
+                    $symbolVisibility = $parameter->isEdaSymbolVisibility() ?? $this->kiCadEDASettings->defaultParameterSymbolVisibility;
+                    $result['fields'][$fieldName] = $this->createField($parameter->getFormattedValue(), $symbolVisibility);
                 }
             }
         }

--- a/src/Settings/MiscSettings/KiCadEDASettings.php
+++ b/src/Settings/MiscSettings/KiCadEDASettings.php
@@ -57,6 +57,13 @@ class KiCadEDASettings
     public bool $defaultParameterVisibility = false;
 
     #[SettingsParameter(
+        label: new TM("settings.misc.kicad_eda.default_parameter_symbol_visibility"),
+        description: new TM("settings.misc.kicad_eda.default_parameter_symbol_visibility.help"),
+
+    )]
+    public bool $defaultParameterSymbolVisibility = false;
+
+    #[SettingsParameter(
         label: new TM("settings.misc.kicad_eda.default_orderdetails_visibility"),
         description: new TM("settings.misc.kicad_eda.default_orderdetails_visibility.help"),
 

--- a/templates/parts/edit/_specifications.html.twig
+++ b/templates/parts/edit/_specifications.html.twig
@@ -15,6 +15,7 @@
             <th>{% trans %}specifications.text{% endtrans %}</th>
             <th>{% trans %}specifications.group{% endtrans %}</th>
             <th title="{% trans %}specifications.eda_visibility.help{% endtrans %}"><i class="fas fa-bolt fa-fw"></i></th>
+            <th title="{% trans %}specifications.eda_symbol_visibility.help{% endtrans %}"><i class="fas fa-eye fa-fw"></i></th>
             <th></th>
         </tr>
         </thead>

--- a/templates/parts/edit/edit_form_styles.html.twig
+++ b/templates/parts/edit/edit_form_styles.html.twig
@@ -83,6 +83,9 @@
         {% if form.eda_visibility is defined %}
         <td class="text-center">{{ form_widget(form.eda_visibility) }}</td>
         {% endif %}
+        {% if form.eda_symbol_visibility is defined %}
+        <td class="text-center">{{ form_widget(form.eda_symbol_visibility) }}</td>
+        {% endif %}
         <td>
             <button type="button" class="btn btn-danger btn-sm order_btn_delete position-relative {% if form.parent.vars.allow_delete is defined and  not form.parent.vars.allow_delete %}disabled{% endif %}"
                     {{ collection.delete_btn() }} title="{% trans %}orderdetail.delete{% endtrans %}">

--- a/tests/Services/EDA/KiCadHelperTest.php
+++ b/tests/Services/EDA/KiCadHelperTest.php
@@ -389,6 +389,37 @@ final class KiCadHelperTest extends KernelTestCase
 
         self::assertArrayHasKey('Voltage Rating', $result['fields']);
         self::assertSame('3.3 V', $result['fields']['Voltage Rating']['value']);
+        //Without an explicit symbol visibility the field defaults to not being shown in the symbol
+        self::assertSame('False', $result['fields']['Voltage Rating']['visible']);
+    }
+
+    /**
+     * Test that a parameter with eda_symbol_visibility=true is marked visible in the symbol.
+     */
+    public function testParameterWithSymbolVisibilityIsVisibleInSymbol(): void
+    {
+        $category = $this->em->find(Category::class, 1);
+
+        $part = new Part();
+        $part->setName('Part with Symbol-Visible Parameter');
+        $part->setCategory($category);
+
+        $param = new PartParameter();
+        $param->setName('Voltage Rating');
+        $param->setValueTypical(3.3);
+        $param->setUnit('V');
+        $param->setEdaVisibility(true);
+        $param->setEdaSymbolVisibility(true);
+        $part->addParameter($param);
+
+        $this->em->persist($part);
+        $this->em->flush();
+
+        $result = $this->helper->getKiCADPart($part);
+
+        self::assertArrayHasKey('Voltage Rating', $result['fields']);
+        self::assertSame('3.3 V', $result['fields']['Voltage Rating']['value']);
+        self::assertSame('True', $result['fields']['Voltage Rating']['visible']);
     }
 
     /**

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -648,7 +648,7 @@ Sub elements will be moved upwards.</target>
         <target>Export this parameter as an EDA field</target>
       </segment>
     </unit>
-    <unit id="edaSymVis1" name="specifications.eda_symbol_visibility.help">
+    <unit id="Nx6h9XW" name="specifications.eda_symbol_visibility.help">
       <segment state="translated">
         <source>specifications.eda_symbol_visibility.help</source>
         <target>Make this parameter field visible in the schematic symbol</target>
@@ -13025,13 +13025,13 @@ Buerklin-API Authentication server:
         <target>EDA visibility for all [part] parameters who does not have an explicit visibility set. When enabled all parameters will be visible in the EDA software by default.</target>
       </segment>
     </unit>
-    <unit id="edaSymVis2" name="settings.misc.kicad_eda.default_parameter_symbol_visibility">
+    <unit id="XchzDpI" name="settings.misc.kicad_eda.default_parameter_symbol_visibility">
       <segment state="translated">
         <source>settings.misc.kicad_eda.default_parameter_symbol_visibility</source>
         <target>Default symbol visibility of parameters</target>
       </segment>
     </unit>
-    <unit id="edaSymVis3" name="settings.misc.kicad_eda.default_parameter_symbol_visibility.help">
+    <unit id="zLHkPCx" name="settings.misc.kicad_eda.default_parameter_symbol_visibility.help">
       <segment state="translated">
         <source>settings.misc.kicad_eda.default_parameter_symbol_visibility.help</source>
         <target>Whether exported [part] parameter fields that do not have an explicit symbol visibility set are shown in the schematic symbol (the KiCad field's "visible" flag). Only affects parameters that are already exported as EDA fields.</target>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -648,6 +648,12 @@ Sub elements will be moved upwards.</target>
         <target>Export this parameter as an EDA field</target>
       </segment>
     </unit>
+    <unit id="edaSymVis1" name="specifications.eda_symbol_visibility.help">
+      <segment state="translated">
+        <source>specifications.eda_symbol_visibility.help</source>
+        <target>Make this parameter field visible in the schematic symbol</target>
+      </segment>
+    </unit>
     <unit id="XclPxI9" name="specification.create">
       <segment state="translated">
         <source>specification.create</source>
@@ -13017,6 +13023,18 @@ Buerklin-API Authentication server:
       <segment state="translated">
         <source>settings.misc.kicad_eda.default_parameter_visibility.help</source>
         <target>EDA visibility for all [part] parameters who does not have an explicit visibility set. When enabled all parameters will be visible in the EDA software by default.</target>
+      </segment>
+    </unit>
+    <unit id="edaSymVis2" name="settings.misc.kicad_eda.default_parameter_symbol_visibility">
+      <segment state="translated">
+        <source>settings.misc.kicad_eda.default_parameter_symbol_visibility</source>
+        <target>Default symbol visibility of parameters</target>
+      </segment>
+    </unit>
+    <unit id="edaSymVis3" name="settings.misc.kicad_eda.default_parameter_symbol_visibility.help">
+      <segment state="translated">
+        <source>settings.misc.kicad_eda.default_parameter_symbol_visibility.help</source>
+        <target>Whether exported [part] parameter fields that do not have an explicit symbol visibility set are shown in the schematic symbol (the KiCad field's "visible" flag). Only affects parameters that are already exported as EDA fields.</target>
       </segment>
     </unit>
     <unit id="J6pYnaC" name="settings.misc.kicad_eda.default_orderdetails_visibility">


### PR DESCRIPTION
## Summary

Adds a per-part-parameter flag that controls whether an exported parameter is
shown **on the schematic symbol** in KiCad, i.e. the KiCad field's `"visible"`
attribute in the EDA HTTP-library API response.

Previously Part-DB always emitted parameter fields with `"visible": "False"`,
so a parameter exported to KiCad was never displayed on the symbol without the
user manually toggling it in KiCad. This adds first-class control over that.

## Two independent "visibilities"

The existing `eda_visibility` and the new `eda_symbol_visibility` do different
things and are deliberately independent:

| Flag | Controls |
|------|----------|
| `eda_visibility` (existing) | Whether the parameter is **exported as a field** at all |
| `eda_symbol_visibility` (new) | Whether that field is **visible on the schematic symbol** (`"visible": "True"/"False"`) |

The new flag only has an effect once the parameter is actually exported.

## Behavior

- `eda_symbol_visibility` is a **nullable tri-state** on part parameters,
  mirroring the existing `eda_visibility`.
- When it is `null`, the new system default
  `KiCadEDASettings::defaultParameterSymbolVisibility` applies.
- Both default to `false`, so **existing installations keep the previous
  behavior** — exported parameter fields stay `"visible": "False"` until the
  flag (or the setting) is turned on. Fully backward compatible.

## Changes

- **Entity** – new nullable `eda_symbol_visibility` column on `AbstractParameter`
  with accessors and matching serialization groups; multi-platform migration
  (MySQL / SQLite / PostgreSQL).
- **Form** – a second `TriStateCheckboxType`, shown for part parameters only.
- **KiCadHelper** – resolves the flag (explicit value, else the system default)
  and passes it to `createField()`.
- **Settings** – `defaultParameterSymbolVisibility` (default `false`).
- **Templates** – new eye-icon column in the part edit *Specifications* table,
  next to the existing EDA-export column.
- **Translations** – English strings for the new tooltip and settings entries.
- **Tests** – assert `"visible": "True"` when the flag is set, and that the
  default stays `"False"`.

## Screenshot
<img width="2103" height="395" alt="partdb-EDA-visibility" src="https://github.com/user-attachments/assets/9abfd7de-545f-41f1-a1ea-143f6f215ac8" />

## Testing

- `KiCadHelperTest` passes (24 tests, 45 assertions), including the two new cases.
- Migration applies cleanly on SQLite; the `eda_symbol_visibility` column is
  created as expected.
- Smoke-tested in the Docker image: container boots, migration runs on startup,
  the new column is present, and the edit form renders the new column.

## Notes

- Scope is **part parameters only** — orderdetails/supplier fields are not
  touched (could follow the same pattern later if wanted).
- Only `messages.en.xlf` is updated; other locales fall back to English until
  Crowdin syncs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
