### PR TITLE
Consider the prices of built instances of subprojects

### DIFF
--- a/src/Services/ProjectSystem/ProjectBuildHelper.php
+++ b/src/Services/ProjectSystem/ProjectBuildHelper.php
@@ -244,7 +244,7 @@ final readonly class ProjectBuildHelper
     private function getBomEntryUnitPrice(ProjectBOMEntry $entry, int $number_of_builds, ?Currency $currency): ?BigDecimal
     {        
         if ($entry->getPart() && $entry->getPart()->getBuiltProject() instanceof Project){
-            return $this->calculateTotalBuildPrice($entry->getPart()->getBuiltProject(), intval($entry->getQuantity()), $entry->getPriceCurrency());
+            return $this->calculateTotalBuildPrice($entry->getPart()->getBuiltProject(), 1, $entry->getPriceCurrency());
         }
         
         if ($entry->getPart() instanceof Part) {

--- a/src/Services/ProjectSystem/ProjectBuildHelper.php
+++ b/src/Services/ProjectSystem/ProjectBuildHelper.php
@@ -242,7 +242,11 @@ final readonly class ProjectBuildHelper
      * taking bulk pricing into account for N builds.
      */
     private function getBomEntryUnitPrice(ProjectBOMEntry $entry, int $number_of_builds, ?Currency $currency): ?BigDecimal
-    {
+    {        
+        if ($entry->getPart() && $entry->getPart()->getBuiltProject() instanceof Project){
+            return $this->calculateTotalBuildPrice($entry->getPart()->getBuiltProject(), intval($entry->getQuantity()), $entry->getPriceCurrency());
+        }
+        
         if ($entry->getPart() instanceof Part) {
             $total_qty = $entry->getQuantity() * $number_of_builds;
             $min_order = $this->pricedetailHelper->getMinOrderAmount($entry->getPart());

--- a/tests/Services/ProjectSystem/ProjectBuildHelperTest.php
+++ b/tests/Services/ProjectSystem/ProjectBuildHelperTest.php
@@ -219,7 +219,7 @@ final class ProjectBuildHelperTest extends WebTestCase
         $subproject = new Project();
         $subentry = new ProjectBOMEntry();
         $subentry->setPart($this->makePartWithPrice(3.5));
-        $subentry->setQuantity(2);
+        $subentry->setQuantity(3);
         $subproject->addBomEntry($subentry);
 
         $part = new Part();
@@ -229,10 +229,10 @@ final class ProjectBuildHelperTest extends WebTestCase
         $part->setBuiltProject($subproject);
         $project->addBomEntry($entry2);
 
-        // 4 × 1.50 + 2 x (2 x 3.5) = 20.00 for 1 build
+        // 4 × 1.50 + 2 x (3 x 3.5) = 27.00 for 1 build
         $result = $this->service->calculateTotalBuildPrice($project, 1);
         $this->assertNotNull($result);
-        $this->assertTrue(BigDecimal::of('20.00')->isEqualTo($result));
+        $this->assertTrue(BigDecimal::of('27.00')->isEqualTo($result));
     }
     
     public function testCalculateUnitBuildPriceEqualsTotal(): void

--- a/tests/Services/ProjectSystem/ProjectBuildHelperTest.php
+++ b/tests/Services/ProjectSystem/ProjectBuildHelperTest.php
@@ -217,15 +217,15 @@ final class ProjectBuildHelperTest extends WebTestCase
         $project->addBomEntry($entry);
         
         $subproject = new Project();
-        $subproject->setParent($project);
         $subentry = new ProjectBOMEntry();
         $subentry->setPart($this->makePartWithPrice(3.5));
         $subentry->setQuantity(2);
         
+        $part = new Part();
         $entry2 = new ProjectBOMEntry();
-        $entry2->setPart(new Part());
+        $part->setBuiltProject($subproject);
+        $entry2->setPart($part);
         $entry2->setQuantity(2);
-        $subproject->setBuildPart($entry2->getPart());
         $project->addBomEntry($entry2);
 
         // 4 × 1.50 + 2 x (2 x 3.5) = 20.00 for 1 build

--- a/tests/Services/ProjectSystem/ProjectBuildHelperTest.php
+++ b/tests/Services/ProjectSystem/ProjectBuildHelperTest.php
@@ -215,17 +215,18 @@ final class ProjectBuildHelperTest extends WebTestCase
         $entry->setPart($this->makePartWithPrice(1.50));
         $entry->setQuantity(4);
         $project->addBomEntry($entry);
-        
+
         $subproject = new Project();
         $subentry = new ProjectBOMEntry();
         $subentry->setPart($this->makePartWithPrice(3.5));
         $subentry->setQuantity(2);
-        
+        $subproject->addBomEntry($subentry);
+
         $part = new Part();
         $entry2 = new ProjectBOMEntry();
-        $part->setBuiltProject($subproject);
         $entry2->setPart($part);
         $entry2->setQuantity(2);
+        $part->setBuiltProject($subproject);
         $project->addBomEntry($entry2);
 
         // 4 × 1.50 + 2 x (2 x 3.5) = 20.00 for 1 build

--- a/tests/Services/ProjectSystem/ProjectBuildHelperTest.php
+++ b/tests/Services/ProjectSystem/ProjectBuildHelperTest.php
@@ -208,6 +208,32 @@ final class ProjectBuildHelperTest extends WebTestCase
         $this->assertTrue(BigDecimal::of('6.00')->isEqualTo($result));
     }
 
+    public function testCalculateTotalBuildPriceWithBuildPartFromSubproject(): void
+    {
+        $project = new Project();
+        $entry = new ProjectBOMEntry();
+        $entry->setPart($this->makePartWithPrice(1.50));
+        $entry->setQuantity(4);
+        $project->addBomEntry($entry);
+        
+        $subproject = new Project();
+        $subproject->setParent($project);
+        $subentry = new ProjectBOMEntry();
+        $subentry->setPart($this->makePartWithPrice(3.5));
+        $subentry->setQuantity(2);
+        
+        $entry2 = new ProjectBOMEntry();
+        $entry2->setPart(new Part());
+        $entry2->setQuantity(2);
+        $subproject->setBuildPart($entry2);
+        $project->addBomEntry($entry2);
+
+        // 4 × 1.50 + 2 x (2 x 3.5) = 20.00 for 1 build
+        $result = $this->service->calculateTotalBuildPrice($project, 1);
+        $this->assertNotNull($result);
+        $this->assertTrue(BigDecimal::of('20.00')->isEqualTo($result));
+    }
+    
     public function testCalculateUnitBuildPriceEqualsTotal(): void
     {
         $project = new Project();

--- a/tests/Services/ProjectSystem/ProjectBuildHelperTest.php
+++ b/tests/Services/ProjectSystem/ProjectBuildHelperTest.php
@@ -225,7 +225,7 @@ final class ProjectBuildHelperTest extends WebTestCase
         $entry2 = new ProjectBOMEntry();
         $entry2->setPart(new Part());
         $entry2->setQuantity(2);
-        $subproject->setBuildPart($entry2);
+        $subproject->setBuildPart($entry2->getPart());
         $project->addBomEntry($entry2);
 
         // 4 × 1.50 + 2 x (2 x 3.5) = 20.00 for 1 build


### PR DESCRIPTION
This way the total price of a project sums up correctly when it contains subprojects with "built" parts (even if those parts have no explicit shopping information, but a BOM cost). Fixes #1457 