### PR TITLE
Fix TypeError when tree expand/collapse/search is used before the tree finished loading

### DIFF
--- a/assets/controllers/elements/tree_controller.js
+++ b/assets/controllers/elements/tree_controller.js
@@ -141,14 +141,26 @@ export default class extends Controller {
     }
 
     collapseAll() {
+        //These actions can be triggered (button click / search input) before the tree data has
+        //finished loading asynchronously, at which point this._tree is still null.
+        if (!this._isInitialized()) {
+            return;
+        }
         this._tree.collapseAll({silent: true});
     }
 
     expandAll() {
+        if (!this._isInitialized()) {
+            return;
+        }
         this._tree.expandAll({silent: true});
     }
 
     searchInput(event) {
+        if (!this._isInitialized()) {
+            return;
+        }
+
         const data = event.target.value;
         //Do nothing if no data was passed
 


### PR DESCRIPTION
## Problem

The sidebar tree's `collapseAll()`, `expandAll()` and `searchInput()` Stimulus actions call methods on `this._tree`, which is only assigned in `_fillTree()` **after** the tree data has been fetched asynchronously (`_getData()` in `reinitTree()`).

If the expand-all / collapse-all button is clicked, or something is typed into the tree search box, before that fetch completes, `this._tree` is still `null` and the browser throws:

```
TypeError: Cannot read properties of null (reading 'expandAll')
    at ...tree_controller.js
    Error invoking action "click->elements--sidebar-tree#expandAll"
```

It is easy to hit on a cold cache / slow first load. The tree works normally once loaded — this is just an unhandled early interaction.

## Fix

Guard the three actions with the controller's existing `_isInitialized()` helper (it already returns `this._tree !== null`), so they are no-ops until the tree is ready. One short guard per method; no behaviour change once the tree has loaded.
