### PR TITLE
Include part fields in the KiCad category listing (one request per category instead of one per part)

### DIFF
--- a/src/Services/EDA/KiCadHelper.php
+++ b/src/Services/EDA/KiCadHelper.php
@@ -148,7 +148,7 @@ class KiCadHelper
     {
         $cacheKey = 'kicad_category_parts_'.($category?->getID() ?? 0) . '_' . $this->category_depth . ($minimal ? '_min' : '');
         return $this->kicadCache->get($cacheKey,
-            function (ItemInterface $item) use ($category) {
+            function (ItemInterface $item) use ($category, $minimal) {
                 $item->tag([
                     $this->tagGenerator->getElementTypeCacheTag(Category::class),
                     $this->tagGenerator->getElementTypeCacheTag(Part::class),
@@ -182,11 +182,21 @@ class KiCadHelper
                         continue;
                     }
 
-                    $result[] = [
-                        'id' => (string)$part->getId(),
-                        'name' => $part->getName(),
-                        'description' => $part->getDescription(),
-                    ];
+                    //A minimal listing carries just enough to populate the chooser's
+                    //name column. Otherwise inline the same record the per-part
+                    //endpoint returns: KiCad skips its follow-up request for every
+                    //part whose listing entry already carries a "fields" object
+                    //(see HTTP_LIB_CONNECTION::SelectAll), which turns a cold library
+                    //open from one request per part into one request per category.
+                    if ($minimal) {
+                        $result[] = [
+                            'id' => (string)$part->getId(),
+                            'name' => $part->getName(),
+                            'description' => $part->getDescription(),
+                        ];
+                    } else {
+                        $result[] = $this->getKiCADPart($part);
+                    }
                 }
 
                 return $result;

--- a/tests/Services/EDA/KiCadHelperTest.php
+++ b/tests/Services/EDA/KiCadHelperTest.php
@@ -632,4 +632,57 @@ final class KiCadHelperTest extends KernelTestCase
         // Empty-named parameter should not appear
         self::assertArrayNotHasKey('', $result['fields']);
     }
+
+    /**
+     * Category 1 (from fixtures) has a KiCad symbol set, so its parts are visible to the EDA.
+     * The listing must carry the fields, so KiCad does not have to request each part separately.
+     */
+    public function testCategoryPartsListingContainsFields(): void
+    {
+        $category = $this->em->find(Category::class, 1);
+
+        $result = $this->helper->getCategoryParts($category);
+
+        self::assertNotEmpty($result);
+        foreach ($result as $part) {
+            self::assertArrayHasKey('fields', $part);
+            self::assertIsArray($part['fields']);
+            //Every part gets at least these, either from itself or from its category
+            self::assertArrayHasKey('reference', $part['fields']);
+            self::assertArrayHasKey('value', $part['fields']);
+            self::assertArrayHasKey('footprint', $part['fields']);
+            self::assertArrayHasKey('symbolIdStr', $part);
+        }
+    }
+
+    /**
+     * The minimal listing stays minimal: id, name and description only.
+     */
+    public function testMinimalCategoryPartsListingContainsNoFields(): void
+    {
+        $category = $this->em->find(Category::class, 1);
+
+        $result = $this->helper->getCategoryParts($category, true);
+
+        self::assertNotEmpty($result);
+        foreach ($result as $part) {
+            self::assertSame(['id', 'name', 'description'], array_keys($part));
+        }
+    }
+
+    /**
+     * The minimal and the full listing must describe the same parts, in the same order.
+     */
+    public function testMinimalAndFullCategoryPartsListingsAgreeOnParts(): void
+    {
+        $category = $this->em->find(Category::class, 1);
+
+        $minimal = $this->helper->getCategoryParts($category, true);
+        $full = $this->helper->getCategoryParts($category);
+
+        self::assertSame(
+            array_column($minimal, 'id'),
+            array_column($full, 'id')
+        );
+    }
 }


### PR DESCRIPTION
### What

`getCategoryParts()` returns only `id`/`name`/`description`, so KiCad's symbol chooser has to fetch every part individually when it enumerates the library. This inlines the record `getKiCADPart()` already builds, which lets KiCad skip those requests.

### Why

`SCH_IO_HTTP_LIB::EnumerateSymbolLib()` back-fills each part from `parts/{id}.json` unless the category listing already carried a `fields` object — `HTTP_LIB_CONNECTION::SelectAll()` uses its presence to set `detailsLoaded` (KiCad ≥ 10.0.5, `common/http_lib/http_lib_connection.cpp`). Because the listing omits it, the skip never triggers.

On the 351-part / 14-category instance I measured, that's **366 requests per cold library open instead of 15**. Most of each request is connection setup and round trip rather than server time — for that instance, ~105 ms TCP+TLS and ~50 ms RTT against ~60 ms of server work — so the request count dominates and a cold open takes tens of seconds.

Measured on the same database, same disk, cold cache both times:

| | before | after |
|---|---|---|
| HTTP requests per cold open | 366 | **15** |
| per-part back-fill requests | 351 | **0** |
| server time, cold cache | 2.39 s | 0.21 s |
| server time, warm cache | 1.96 s | 0.09 s |
| total payload | 331 KiB | **302 KiB** |
| slowest single listing | 10 ms | 45 ms (174 parts, 149 KiB) |

The total payload gets *smaller*: 14 batched responses carry less overhead than 351 individual ones. The largest category costs 45 ms cold to assemble, and the result is cached with the same `Part`/`Category`/`Footprint` tags as before, so it is rebuilt exactly as often as it was.

### How

By wiring up the `$minimal` argument `getCategoryParts()` **already accepts** and that `KiCadApiController` **already exposes** as `?minimal=1`. Today that flag has no effect on the response — the cache closure captures only `$category`, so `$minimal` changes the cache key and nothing else. After this change:

- `?minimal=1` → the light `id`/`name`/`description` shape (what the endpoint returns for everyone today),
- default → the same record the per-part endpoint returns, which is a superset of it.

So it also gives users the control asked for in #1464, and keeps a cheap listing available for clients that only need names.

### Tests

Three cases added to `tests/Services/EDA/KiCadHelperTest.php`, using the existing `EDADataFixtures` (category 1 has a KiCad symbol, so its parts are EDA-visible): the default listing carries `fields` plus `symbolIdStr`, `?minimal=1` still returns exactly `id`/`name`/`description`, and both listings describe the same parts in the same order.

### Checks run locally

On PHP 8.4 + SQLite (a cell of the CI matrix), in a container with the extensions CI installs:

| | |
|---|---|
| `bin/phpunit` (full suite) | **1955 tests, 4852 assertions, 0 failures**, 1 skipped |
| `bin/phpunit --filter KiCadHelperTest` | 27 tests (24 existing + the 3 added), 69 assertions |
| `composer phpstan` (level 5) | no errors |
| `bin/console lint:yaml config --parse-tags` | 66 files OK |
| `bin/console lint:twig templates --env=prod` | 176 files OK |
| `bin/console doctrine:schema:validate --skip-sync` | mapping OK |

Not run: the MySQL and PostgreSQL matrix cells, PHP 8.2/8.3/8.5, and Codecov upload. The change builds a PHP array and issues no new queries, so it should be database-agnostic, but I didn't verify that empirically.

Two notes on the tooling while I was in there, both pre-existing and unrelated to this PR:

- `vendor/bin/ecs` can't run: `ecs.php` uses the deprecated `return function (ECSConfig $ecsConfig)` format, and the installed Easy Coding Standard passes an `ECSConfig` where the closure's signature demands a `ContainerConfigurator`, so it fails while building its container before analysing anything. Happy to send a separate PR converting `ecs.php` to the fluent API if that's wanted. I matched the surrounding style in `KiCadHelper.php` by hand instead.
- `CONTRIBUTING.md` says phpstan runs at `--level=2`; the actual `composer phpstan` script and `phpstan.dist.neon` both say level 5. I used level 5.

Refs #1464 — this covers the listing side of that request (a light vs. full listing); it does not add per-parameter selection.
