### PR TITLE
Bump mcp/sdk to v0.7.1 (fixes CVE-2026-53965 SSE buffer DoS)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "league/oauth2-server-bundle": "^1.2.1",
         "liip/imagine-bundle": "^2.2",
         "maennchen/zipstream-php": "2.4.0.1",
-        "mcp/sdk": "v0.7.0 as v0.6.0",
+        "mcp/sdk": "v0.7.1 as v0.6.0",
         "nbgrp/onelogin-saml-bundle": "^v2.0.2",
         "nelexa/zip": "^4.0",
         "nelmio/cors-bundle": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "70676ee929d126a22791ceb192c7be87",
+    "content-hash": "110d0625e62ca7c841a2feaed1132594",
     "packages": [
         {
             "name": "amphp/amp",
@@ -7413,16 +7413,16 @@
         },
         {
             "name": "mcp/sdk",
-            "version": "v0.7.0",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/modelcontextprotocol/php-sdk.git",
-                "reference": "a6f415578fa789783d010274d11c922e97659a8a"
+                "reference": "785fc3b9b7006ecc8a73322c939d96a4a7154345"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/modelcontextprotocol/php-sdk/zipball/a6f415578fa789783d010274d11c922e97659a8a",
-                "reference": "a6f415578fa789783d010274d11c922e97659a8a",
+                "url": "https://api.github.com/repos/modelcontextprotocol/php-sdk/zipball/785fc3b9b7006ecc8a73322c939d96a4a7154345",
+                "reference": "785fc3b9b7006ecc8a73322c939d96a4a7154345",
                 "shasum": ""
             },
             "require": {
@@ -7491,9 +7491,9 @@
             "description": "Model Context Protocol SDK for Client and Server applications in PHP",
             "support": {
                 "issues": "https://github.com/modelcontextprotocol/php-sdk/issues",
-                "source": "https://github.com/modelcontextprotocol/php-sdk/tree/v0.7.0"
+                "source": "https://github.com/modelcontextprotocol/php-sdk/tree/v0.7.1"
             },
-            "time": "2026-07-14T22:58:00+00:00"
+            "time": "2026-08-10T20:09:23+00:00"
         },
         {
             "name": "mf2/mf2",
@@ -23931,7 +23931,7 @@
     "aliases": [
         {
             "package": "mcp/sdk",
-            "version": "0.7.0.0",
+            "version": "0.7.1.0",
             "alias": "v0.6.0",
             "alias_normalized": "0.6.0.0"
         }


### PR DESCRIPTION
## Problem

The Symfony security checker (and `composer audit`) flag **`mcp/sdk` `v0.7.0`** as vulnerable:

- **CVE-2026-53965** / GHSA-7m52-jw36-44r3 — the client `HttpTransport` SSE buffer can grow unbounded when the server withholds the event delimiter, allowing a denial of service. Affected range: `>= 0.5.0, <= 0.7.0`.

This currently fails the `Static analysis` job's "Check dependencies for security" step on master (and consequently on every open PR).

## Fix

Bump the pinned `mcp/sdk` to **`v0.7.1`** (which bounds the SSE buffer), keeping the existing `as v0.6.0` alias. Only the `mcp/sdk` lock entry (and the content-hash) changes — no other dependencies are touched, and `composer update` reports *"No security vulnerability advisories found."*
