### PR TITLE
Add Web NFC support for writing and scanning NFC tags

### DIFF
--- a/assets/controllers/pages/barcode_scan_controller.js
+++ b/assets/controllers/pages/barcode_scan_controller.js
@@ -21,6 +21,7 @@ import {Controller} from "@hotwired/stimulus";
 //import * as ZXing from "@zxing/library";
 
 import {Html5QrcodeScanner, Html5Qrcode} from "@part-db/html5-qrcode";
+import { generateCsrfToken, generateCsrfHeaders } from "../csrf_protection_controller";
 import {decodeNdefMessage, isWebNfcAvailable, setScanInputAndSubmit} from "./nfc_helpers";
 
 /* stimulusFetch: 'lazy' */

--- a/assets/controllers/pages/barcode_scan_controller.js
+++ b/assets/controllers/pages/barcode_scan_controller.js
@@ -21,7 +21,7 @@ import {Controller} from "@hotwired/stimulus";
 //import * as ZXing from "@zxing/library";
 
 import {Html5QrcodeScanner, Html5Qrcode} from "@part-db/html5-qrcode";
-import { generateCsrfToken, generateCsrfHeaders } from "../csrf_protection_controller";
+import {decodeNdefMessage, isWebNfcAvailable, setScanInputAndSubmit} from "./nfc_helpers";
 
 /* stimulusFetch: 'lazy' */
 
@@ -30,6 +30,9 @@ export default class extends Controller {
     _submitting = false;
     _lastDecodedText = "";
     _onInfoChange = null;
+    _nfcAbortController = null;
+
+    static targets = ["reader", "nfcControls", "nfcButton", "nfcStatus"];
 
     connect() {
 
@@ -63,7 +66,7 @@ export default class extends Controller {
             document.getElementById("scanner-warning")?.classList.remove("d-none");
         });
 
-        this._scanner = new Html5QrcodeScanner(this.element.id, {
+        this._scanner = new Html5QrcodeScanner(this.readerTarget.id, {
             fps: 10,
             qrbox: qrboxFunction,
             // Key change: shrink preview height on mobile
@@ -75,6 +78,10 @@ export default class extends Controller {
         }, false);
 
         this._scanner.render(this.onScanSuccess.bind(this));
+
+        if (isWebNfcAvailable() && this.hasNfcControlsTarget) {
+            this.nfcControlsTarget.classList.remove("d-none");
+        }
     }
 
     disconnect() {
@@ -83,6 +90,8 @@ export default class extends Controller {
         const scanner = this._scanner;
         this._scanner = null;
         this._lastDecodedText = "";
+        this._nfcAbortController?.abort();
+        this._nfcAbortController = null;
 
         // Unbind info-mode change handler (always do this, even if scanner is null)
         const info = document.getElementById("scan_dialog_info_mode");
@@ -114,12 +123,41 @@ export default class extends Controller {
         // Mark as handled immediately (prevents spam even if callback fires repeatedly)
         this._lastDecodedText = normalized;
 
-        const input = document.getElementById('scan_dialog_input');
-        input.value = decodedText;
-        //Trigger nonprintable char input controller to update the hidden input value
-        input.dispatchEvent(new Event('input', { bubbles: true }));
+        setScanInputAndSubmit(decodedText);
+    }
 
-        //Submit form
-        document.getElementById('scan_dialog_form').requestSubmit();
+    async startNfcScan() {
+        if (!isWebNfcAvailable() || this._nfcAbortController) return;
+
+        this._nfcAbortController = new AbortController();
+        this.nfcButtonTarget.disabled = true;
+        this.nfcStatusTarget.textContent = this.nfcStatusTarget.dataset.waiting;
+
+        try {
+            const reader = new NDEFReader();
+            await reader.scan({signal: this._nfcAbortController.signal});
+            reader.addEventListener("readingerror", () => {
+                this.nfcStatusTarget.textContent = this.nfcStatusTarget.dataset.readError;
+            });
+            reader.addEventListener("reading", ({message}) => {
+                const value = decodeNdefMessage(message);
+                if (!value) {
+                    this.nfcStatusTarget.textContent = this.nfcStatusTarget.dataset.unsupportedRecord;
+                    return;
+                }
+
+                this._nfcAbortController?.abort();
+                this._nfcAbortController = null;
+                setScanInputAndSubmit(value);
+            });
+        } catch (error) {
+            if (error.name !== "AbortError") {
+                this.nfcStatusTarget.textContent = error.name === "NotAllowedError"
+                    ? this.nfcStatusTarget.dataset.permissionDenied
+                    : this.nfcStatusTarget.dataset.failed;
+            }
+            this._nfcAbortController = null;
+            this.nfcButtonTarget.disabled = false;
+        }
     }
 }

--- a/assets/controllers/pages/nfc_helpers.js
+++ b/assets/controllers/pages/nfc_helpers.js
@@ -1,3 +1,22 @@
+/*
+ * This file is part of Part-DB (https://github.com/Part-DB/Part-DB-symfony).
+ *
+ *  Copyright (C) 2019 - 2026 Jan Böhmer (https://github.com/jbtronics)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 export function isWebNfcAvailable() {
     return window.isSecureContext && "NDEFReader" in window;
 }

--- a/assets/controllers/pages/nfc_helpers.js
+++ b/assets/controllers/pages/nfc_helpers.js
@@ -1,0 +1,29 @@
+export function isWebNfcAvailable() {
+    return window.isSecureContext && "NDEFReader" in window;
+}
+
+export function decodeNdefMessage(message) {
+    for (const record of message.records) {
+        if (!["url", "absolute-url", "text"].includes(record.recordType) || !record.data) continue;
+
+        try {
+            const value = new TextDecoder(record.encoding || "utf-8").decode(record.data).trim();
+            if (value) return value;
+        } catch (_) {
+            // Ignore records with unsupported encodings and try the next record.
+        }
+    }
+
+    return null;
+}
+
+export function setScanInputAndSubmit(value) {
+    const input = document.getElementById("scan_dialog_input");
+    const form = document.getElementById("scan_dialog_form");
+    if (!input || !form) return false;
+
+    input.value = value;
+    input.dispatchEvent(new Event("input", {bubbles: true}));
+    form.requestSubmit();
+    return true;
+}

--- a/assets/controllers/pages/nfc_write_controller.js
+++ b/assets/controllers/pages/nfc_write_controller.js
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Part-DB (https://github.com/Part-DB/Part-DB-symfony).
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {Controller} from "@hotwired/stimulus";
+import {isWebNfcAvailable} from "./nfc_helpers";
+
+/* stimulusFetch: 'lazy' */
+
+export default class extends Controller {
+    static targets = ["button", "overwriteButton", "status"];
+    static values = {url: String};
+    _abortController = null;
+
+    connect() {
+        if (isWebNfcAvailable()) this.element.classList.remove("d-none");
+    }
+
+    disconnect() {
+        this._abortController?.abort();
+        this._abortController = null;
+    }
+
+    async write(event) {
+        await this._write(event.currentTarget.dataset.overwrite === "true");
+    }
+
+    async _write(overwrite) {
+        if (this._abortController) return;
+
+        this._abortController = new AbortController();
+        this.buttonTarget.disabled = true;
+        this.overwriteButtonTarget.disabled = true;
+        this.overwriteButtonTarget.classList.add("d-none");
+        this.statusTarget.className = "small text-muted mt-2";
+        this.statusTarget.textContent = this.statusTarget.dataset.waiting;
+
+        try {
+            const writer = new NDEFReader();
+            await writer.write(
+                {records: [{recordType: "url", data: this.urlValue}]},
+                {overwrite, signal: this._abortController.signal},
+            );
+            this.statusTarget.className = "small text-success mt-2";
+            this.statusTarget.textContent = this.statusTarget.dataset.success;
+        } catch (error) {
+            await this._showError(error, overwrite);
+        } finally {
+            this._abortController = null;
+            this.buttonTarget.disabled = false;
+        }
+    }
+
+    async _showError(error, overwrite) {
+        this.statusTarget.className = "small text-danger mt-2";
+
+        if (error.name === "NotAllowedError" && !overwrite) {
+            try {
+                const permission = await navigator.permissions.query({name: "nfc"});
+                if (permission.state === "denied") {
+                    this.statusTarget.textContent = this.statusTarget.dataset.permissionDenied;
+                    return;
+                }
+            } catch (_) {
+                // The NFC permission descriptor is not exposed by every supporting browser.
+            }
+
+            this.statusTarget.textContent = this.statusTarget.dataset.overwriteWarning;
+            this.overwriteButtonTarget.classList.remove("d-none");
+            this.overwriteButtonTarget.disabled = false;
+            return;
+        }
+
+        const messageKey = {
+            NotAllowedError: "permissionDenied",
+            NotSupportedError: "unsupportedTag",
+            NetworkError: "writeFailed",
+            AbortError: "cancelled",
+        }[error.name] || "writeFailed";
+        this.statusTarget.textContent = this.statusTarget.dataset[messageKey];
+    }
+}

--- a/assets/controllers/pages/nfc_write_controller.js
+++ b/assets/controllers/pages/nfc_write_controller.js
@@ -57,7 +57,7 @@ export default class extends Controller {
 
         if (error.name === "NotAllowedError" && !overwrite) {
             try {
-                const permission = await navigator.permissions.query({name: "nfc"});
+                const permission = await navigator.permissions?.query({name: "nfc"});
                 if (permission.state === "denied") {
                     this.statusTarget.textContent = this.statusTarget.dataset.permissionDenied;
                     return;
@@ -66,14 +66,14 @@ export default class extends Controller {
                 // The NFC permission descriptor is not exposed by every supporting browser.
             }
 
-            this.statusTarget.textContent = this.statusTarget.dataset.overwriteWarning;
+            this.statusTarget.textContent = this.statusTarget.dataset.overwriteConfirmation;
             this.overwriteButtonTarget.classList.remove("d-none");
             this.overwriteButtonTarget.disabled = false;
             return;
         }
 
         const messageKey = {
-            NotAllowedError: "permissionDenied",
+            NotAllowedError: "notAllowed",
             NotSupportedError: "unsupportedTag",
             NetworkError: "writeFailed",
             AbortError: "cancelled",

--- a/docs/usage/scanner.md
+++ b/docs/usage/scanner.md
@@ -1,10 +1,10 @@
 ---
-title: Barcode Scanner
+title: Barcode and NFC Scanner
 layout: default
 parent: Usage
 ---
 
-# Barcode scanner
+# Barcode and NFC scanner
 
 When the user has the correct permission there will be a barcode scanner button in the navbar.
 On this page you can either input a barcode code by hand, use an external barcode scanner, or use your devices camera to
@@ -49,3 +49,15 @@ of the scanned barcode, Part-DB will automatically scan the barcode that comes a
 and redirects you to the corresponding page.
 This allows you to quickly scan a barcode from anywhere in Part-DB without the need to first open the scanner page.
 If an input field is focused, the barcode will be entered into the field as usual and no redirection will happen.
+
+## Using NFC stickers
+
+On devices with Web NFC support, the scanner page also shows a **Scan NFC tag** button. NFC access requires an NFC-capable
+Android device, a supporting browser, HTTPS, and permission from the user. Part-DB reads URL and text records from NDEF tags
+and processes their content in exactly the same way as a camera or external barcode scan. Camera and manual input remain
+available on devices without Web NFC.
+
+Users with permission to create labels can enroll a sticker for a saved part from the part's **Tools** tab. **Write NFC tag**
+writes the same Part-DB URL used by an internal QR label. The first write protects existing tag contents; if the tag is already
+programmed, Part-DB asks for confirmation and requires the tag to be tapped again before overwriting it. Tags remain writable,
+and Part-DB does not store their hardware identifiers or enrollment state.

--- a/src/Controller/PartController.php
+++ b/src/Controller/PartController.php
@@ -155,7 +155,9 @@ final class PartController extends AbstractController
                 'withdraw_add_helper' => $withdrawAddHelper,
                 'highlightLotId' => $request->query->getInt('highlightLot', 0),
                 'add_lot_form' => $addLotForm,
-                'nfc_url' => $timeTravel_timestamp === null ? $barcodeContentGenerator->getURLContent($part) : null,
+                'nfc_url' => $timeTravel_timestamp === null && $this->isGranted('@labels.create_labels')
+                    ? $barcodeContentGenerator->getURLContent($part)
+                    : null,
             ]
         );
     }

--- a/src/Controller/PartController.php
+++ b/src/Controller/PartController.php
@@ -42,6 +42,7 @@ use App\Services\Attachments\PartPreviewGenerator;
 use App\Services\EntityMergers\Mergers\PartMerger;
 use App\Services\InfoProviderSystem\PartInfoRetriever;
 use App\Services\InfoProviderSystem\Providers\InfoProviderInterface;
+use App\Services\LabelSystem\Barcodes\BarcodeContentGenerator;
 use App\Services\LogSystem\EventCommentHelper;
 use App\Services\LogSystem\HistoryHelper;
 use App\Services\LogSystem\TimeTravel;
@@ -98,6 +99,7 @@ final class PartController extends AbstractController
         DataTableFactory $dataTable,
         ParameterExtractor $parameterExtractor,
         PartLotWithdrawAddHelper $withdrawAddHelper,
+        BarcodeContentGenerator $barcodeContentGenerator,
         ?string $timestamp = null
     ): Response {
         $this->denyAccessUnlessGranted('read', $part);
@@ -153,6 +155,7 @@ final class PartController extends AbstractController
                 'withdraw_add_helper' => $withdrawAddHelper,
                 'highlightLotId' => $request->query->getInt('highlightLot', 0),
                 'add_lot_form' => $addLotForm,
+                'nfc_url' => $timeTravel_timestamp === null ? $barcodeContentGenerator->getURLContent($part) : null,
             ]
         );
     }

--- a/templates/label_system/scanner/scanner.html.twig
+++ b/templates/label_system/scanner/scanner.html.twig
@@ -11,7 +11,23 @@
         <div class="form-group row">
             <div class="{{ offset_label }} {{ col_input }}">
                 <div class="img-thumbnail" style="max-width: 600px;">
-                    <div id="reader-box" {{ stimulus_controller('pages/barcode_scan') }}></div>
+                    <div {{ stimulus_controller('pages/barcode_scan') }}>
+                        <div class="d-none mb-3" {{ stimulus_target('pages/barcode_scan', 'nfcControls') }}>
+                            <button type="button" class="btn btn-outline-primary"
+                                    {{ stimulus_target('pages/barcode_scan', 'nfcButton') }}
+                                    {{ stimulus_action('pages/barcode_scan', 'startNfcScan') }}>
+                                <i class="fa-solid fa-wifi fa-rotate-90 fa-fw"></i>
+                                {% trans %}label_scanner.nfc.scan{% endtrans %}
+                            </button>
+                            <div class="small text-muted mt-2" {{ stimulus_target('pages/barcode_scan', 'nfcStatus') }}
+                                 data-waiting="{{ 'label_scanner.nfc.waiting'|trans }}"
+                                 data-read-error="{{ 'label_scanner.nfc.read_error'|trans }}"
+                                 data-unsupported-record="{{ 'label_scanner.nfc.unsupported_record'|trans }}"
+                                 data-permission-denied="{{ 'label_scanner.nfc.permission_denied'|trans }}"
+                                 data-failed="{{ 'label_scanner.nfc.failed'|trans }}"></div>
+                        </div>
+                        <div id="reader-box" {{ stimulus_target('pages/barcode_scan', 'reader') }}></div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/templates/label_system/scanner/scanner.html.twig
+++ b/templates/label_system/scanner/scanner.html.twig
@@ -19,7 +19,8 @@
                                 <i class="fa-solid fa-wifi fa-rotate-90 fa-fw"></i>
                                 {% trans %}label_scanner.nfc.scan{% endtrans %}
                             </button>
-                            <div class="small text-muted mt-2" {{ stimulus_target('pages/barcode_scan', 'nfcStatus') }}
+                            <div class="small text-muted mt-2" role="status" aria-live="polite"
+                                 {{ stimulus_target('pages/barcode_scan', 'nfcStatus') }}
                                  data-waiting="{{ 'label_scanner.nfc.waiting'|trans }}"
                                  data-read-error="{{ 'label_scanner.nfc.read_error'|trans }}"
                                  data-unsupported-record="{{ 'label_scanner.nfc.unsupported_record'|trans }}"

--- a/templates/parts/info/_tools.html.twig
+++ b/templates/parts/info/_tools.html.twig
@@ -83,7 +83,8 @@
                 {{ stimulus_action('pages/nfc_write', 'write') }}>
             {% trans %}part.info.nfc.write.overwrite_button{% endtrans %}
         </button>
-        <div class="small text-muted mt-2" {{ stimulus_target('pages/nfc_write', 'status') }}
+        <div class="small text-muted mt-2" role="status" aria-live="polite"
+             {{ stimulus_target('pages/nfc_write', 'status') }}
              data-waiting="{{ 'part.info.nfc.write.waiting'|trans }}"
              data-success="{{ 'part.info.nfc.write.success'|trans }}"
              data-overwrite-warning="{{ 'part.info.nfc.write.overwrite_warning'|trans }}"

--- a/templates/parts/info/_tools.html.twig
+++ b/templates/parts/info/_tools.html.twig
@@ -68,6 +68,32 @@
 
 {{ dropdown.profile_dropdown('part', part.id) }}
 
+{% if nfc_url is not null and is_granted('@labels.create_labels') %}
+    <div class="d-none mt-2" {{ stimulus_controller('pages/nfc_write', {url: nfc_url}) }}>
+        <button type="button" class="btn btn-secondary"
+                data-overwrite="false"
+                {{ stimulus_target('pages/nfc_write', 'button') }}
+                {{ stimulus_action('pages/nfc_write', 'write') }}>
+            <i class="fa-solid fa-wifi fa-rotate-90 fa-fw"></i>
+            {% trans %}nfc.write.button{% endtrans %}
+        </button>
+        <button type="button" class="btn btn-danger d-none"
+                data-overwrite="true"
+                {{ stimulus_target('pages/nfc_write', 'overwriteButton') }}
+                {{ stimulus_action('pages/nfc_write', 'write') }}>
+            {% trans %}nfc.write.overwrite_button{% endtrans %}
+        </button>
+        <div class="small text-muted mt-2" {{ stimulus_target('pages/nfc_write', 'status') }}
+             data-waiting="{{ 'nfc.write.waiting'|trans }}"
+             data-success="{{ 'nfc.write.success'|trans }}"
+             data-overwrite-warning="{{ 'nfc.write.overwrite_warning'|trans }}"
+             data-permission-denied="{{ 'nfc.write.permission_denied'|trans }}"
+             data-unsupported-tag="{{ 'nfc.write.unsupported_tag'|trans }}"
+             data-write-failed="{{ 'nfc.write.failed'|trans }}"
+             data-cancelled="{{ 'nfc.write.cancelled'|trans }}"></div>
+    </div>
+{% endif %}
+
 <a class="btn btn-success mt-2" {% if not is_granted('@projects.edit') %}disabled{% endif %}
    href="{{ path('project_add_parts_no_id', {"parts": part.id, "_redirect":  uri_without_host(app.request)}) }}">
     <i class="fa-solid fa-magnifying-glass-plus fa-fw"></i>

--- a/templates/parts/info/_tools.html.twig
+++ b/templates/parts/info/_tools.html.twig
@@ -75,22 +75,22 @@
                 {{ stimulus_target('pages/nfc_write', 'button') }}
                 {{ stimulus_action('pages/nfc_write', 'write') }}>
             <i class="fa-solid fa-wifi fa-rotate-90 fa-fw"></i>
-            {% trans %}nfc.write.button{% endtrans %}
+            {% trans %}part.info.nfc.write.button{% endtrans %}
         </button>
         <button type="button" class="btn btn-danger d-none"
                 data-overwrite="true"
                 {{ stimulus_target('pages/nfc_write', 'overwriteButton') }}
                 {{ stimulus_action('pages/nfc_write', 'write') }}>
-            {% trans %}nfc.write.overwrite_button{% endtrans %}
+            {% trans %}part.info.nfc.write.overwrite_button{% endtrans %}
         </button>
         <div class="small text-muted mt-2" {{ stimulus_target('pages/nfc_write', 'status') }}
-             data-waiting="{{ 'nfc.write.waiting'|trans }}"
-             data-success="{{ 'nfc.write.success'|trans }}"
-             data-overwrite-warning="{{ 'nfc.write.overwrite_warning'|trans }}"
-             data-permission-denied="{{ 'nfc.write.permission_denied'|trans }}"
-             data-unsupported-tag="{{ 'nfc.write.unsupported_tag'|trans }}"
-             data-write-failed="{{ 'nfc.write.failed'|trans }}"
-             data-cancelled="{{ 'nfc.write.cancelled'|trans }}"></div>
+             data-waiting="{{ 'part.info.nfc.write.waiting'|trans }}"
+             data-success="{{ 'part.info.nfc.write.success'|trans }}"
+             data-overwrite-warning="{{ 'part.info.nfc.write.overwrite_warning'|trans }}"
+             data-permission-denied="{{ 'part.info.nfc.write.permission_denied'|trans }}"
+             data-unsupported-tag="{{ 'part.info.nfc.write.unsupported_tag'|trans }}"
+             data-write-failed="{{ 'part.info.nfc.write.failed'|trans }}"
+             data-cancelled="{{ 'part.info.nfc.write.cancelled'|trans }}"></div>
     </div>
 {% endif %}
 

--- a/templates/parts/info/_tools.html.twig
+++ b/templates/parts/info/_tools.html.twig
@@ -87,8 +87,9 @@
              {{ stimulus_target('pages/nfc_write', 'status') }}
              data-waiting="{{ 'part.info.nfc.write.waiting'|trans }}"
              data-success="{{ 'part.info.nfc.write.success'|trans }}"
-             data-overwrite-warning="{{ 'part.info.nfc.write.overwrite_warning'|trans }}"
+             data-overwrite-confirmation="{{ 'part.info.nfc.write.overwrite_confirmation'|trans }}"
              data-permission-denied="{{ 'part.info.nfc.write.permission_denied'|trans }}"
+             data-not-allowed="{{ 'part.info.nfc.write.not_allowed'|trans }}"
              data-unsupported-tag="{{ 'part.info.nfc.write.unsupported_tag'|trans }}"
              data-write-failed="{{ 'part.info.nfc.write.failed'|trans }}"
              data-cancelled="{{ 'part.info.nfc.write.cancelled'|trans }}"></div>

--- a/templates/parts/info/_tools.html.twig
+++ b/templates/parts/info/_tools.html.twig
@@ -68,7 +68,7 @@
 
 {{ dropdown.profile_dropdown('part', part.id) }}
 
-{% if nfc_url is not null and is_granted('@labels.create_labels') %}
+{% if nfc_url is not null %}
     <div class="d-none mt-2" {{ stimulus_controller('pages/nfc_write', {url: nfc_url}) }}>
         <button type="button" class="btn btn-secondary"
                 data-overwrite="false"

--- a/tests/Controller/PartControllerTest.php
+++ b/tests/Controller/PartControllerTest.php
@@ -30,6 +30,7 @@ use App\Entity\Parts\Manufacturer;
 use App\Entity\Parts\Part;
 use App\Entity\Parts\StorageLocation;
 use App\Entity\Parts\Supplier;
+use App\Entity\UserSystem\PermissionData;
 use App\Entity\UserSystem\User;
 use App\Services\InfoProviderSystem\DTOs\BulkSearchResponseDTO;
 use PHPUnit\Framework\Attributes\Group;
@@ -59,6 +60,26 @@ final class PartControllerTest extends WebTestCase
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
         $this->assertSelectorExists('[data-controller~="pages--nfc-write"]');
         $this->assertSelectorExists('[data-pages--nfc-write-url-value$="/scan/part/' . $part->getId() . '"]');
+    }
+
+    public function testShowPartDoesNotOfferNfcWritingWithoutLabelPermission(): void
+    {
+        $client = static::createClient();
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $user = $entityManager->getRepository(User::class)->findOneBy(['name' => 'admin']);
+        $part = $entityManager->getRepository(Part::class)->find(1);
+
+        if (!$user || !$part) {
+            $this->markTestSkipped('Required test fixtures not found');
+        }
+
+        $user->getPermissions()->setPermissionValue('labels', 'create_labels', PermissionData::DISALLOW);
+        $client->loginUser($user);
+        $client->request('GET', '/en/part/' . $part->getId());
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $this->assertSelectorNotExists('[data-controller~="pages--nfc-write"]');
     }
 
     public function testShowPartWithTimestamp(): void

--- a/tests/Controller/PartControllerTest.php
+++ b/tests/Controller/PartControllerTest.php
@@ -57,6 +57,8 @@ final class PartControllerTest extends WebTestCase
 
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $this->assertSelectorExists('[data-controller~="pages--nfc-write"]');
+        $this->assertSelectorExists('[data-pages--nfc-write-url-value$="/scan/part/' . $part->getId() . '"]');
     }
 
     public function testShowPartWithTimestamp(): void

--- a/tests/Controller/ScanControllerTest.php
+++ b/tests/Controller/ScanControllerTest.php
@@ -51,4 +51,13 @@ final class ScanControllerTest extends WebTestCase
         $this->client->request('GET', '/scan/part/1');
         $this->assertResponseRedirects('/en/part/1');
     }
+
+    public function testScanDialogContainsProgressiveNfcControls(): void
+    {
+        $this->client->request('GET', '/en/scan');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-pages--barcode-scan-target~="nfcControls"]');
+        $this->assertSelectorTextContains('[data-pages--barcode-scan-target~="nfcControls"]', 'Scan NFC tag');
+    }
 }

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -14261,5 +14261,50 @@ Buerklin-API Authentication server:
         <target>OAuth2 client updated successfully!</target>
       </segment>
     </unit>
+    <unit id="nfcScanButton" name="label_scanner.nfc.scan">
+      <segment state="translated"><source>label_scanner.nfc.scan</source><target>Scan NFC tag</target></segment>
+    </unit>
+    <unit id="nfcScanWaiting" name="label_scanner.nfc.waiting">
+      <segment state="translated"><source>label_scanner.nfc.waiting</source><target>Hold an NFC tag near your device…</target></segment>
+    </unit>
+    <unit id="nfcScanReadError" name="label_scanner.nfc.read_error">
+      <segment state="translated"><source>label_scanner.nfc.read_error</source><target>The NFC tag could not be read. Try again.</target></segment>
+    </unit>
+    <unit id="nfcScanUnsupportedRecord" name="label_scanner.nfc.unsupported_record">
+      <segment state="translated"><source>label_scanner.nfc.unsupported_record</source><target>The tag contains no supported URL or text record.</target></segment>
+    </unit>
+    <unit id="nfcScanPermissionDenied" name="label_scanner.nfc.permission_denied">
+      <segment state="translated"><source>label_scanner.nfc.permission_denied</source><target>NFC permission was denied.</target></segment>
+    </unit>
+    <unit id="nfcScanFailed" name="label_scanner.nfc.failed">
+      <segment state="translated"><source>label_scanner.nfc.failed</source><target>NFC scanning could not be started. Check that NFC is enabled.</target></segment>
+    </unit>
+    <unit id="nfcWriteButton" name="nfc.write.button">
+      <segment state="translated"><source>nfc.write.button</source><target>Write NFC tag</target></segment>
+    </unit>
+    <unit id="nfcWriteOverwriteButton" name="nfc.write.overwrite_button">
+      <segment state="translated"><source>nfc.write.overwrite_button</source><target>Confirm overwrite</target></segment>
+    </unit>
+    <unit id="nfcWriteWaiting" name="nfc.write.waiting">
+      <segment state="translated"><source>nfc.write.waiting</source><target>Hold the sticker near your device until writing completes…</target></segment>
+    </unit>
+    <unit id="nfcWriteSuccess" name="nfc.write.success">
+      <segment state="translated"><source>nfc.write.success</source><target>The NFC sticker was enrolled successfully.</target></segment>
+    </unit>
+    <unit id="nfcWriteOverwriteWarning" name="nfc.write.overwrite_warning">
+      <segment state="translated"><source>nfc.write.overwrite_warning</source><target>This tag already contains data. Confirm overwrite, then tap the tag again.</target></segment>
+    </unit>
+    <unit id="nfcWritePermissionDenied" name="nfc.write.permission_denied">
+      <segment state="translated"><source>nfc.write.permission_denied</source><target>NFC permission was denied.</target></segment>
+    </unit>
+    <unit id="nfcWriteUnsupportedTag" name="nfc.write.unsupported_tag">
+      <segment state="translated"><source>nfc.write.unsupported_tag</source><target>This tag is read-only or does not support writable NDEF data.</target></segment>
+    </unit>
+    <unit id="nfcWriteFailed" name="nfc.write.failed">
+      <segment state="translated"><source>nfc.write.failed</source><target>The tag could not be written. Check its capacity and try again.</target></segment>
+    </unit>
+    <unit id="nfcWriteCancelled" name="nfc.write.cancelled">
+      <segment state="translated"><source>nfc.write.cancelled</source><target>NFC writing was cancelled.</target></segment>
+    </unit>
   </file>
 </xliff>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -7185,7 +7185,7 @@ Element 1 -&gt; Element 1.2</target>
     <unit id="6vBfGQ5" name="part.info.nfc.write.overwrite_button">
       <segment state="translated">
         <source>part.info.nfc.write.overwrite_button</source>
-        <target>Confirm overwrite</target>
+        <target>Retry and allow overwrite</target>
       </segment>
     </unit>
     <unit id="b4fnJiH" name="part.info.nfc.write.waiting">
@@ -7200,16 +7200,22 @@ Element 1 -&gt; Element 1.2</target>
         <target>The NFC sticker was enrolled successfully.</target>
       </segment>
     </unit>
-    <unit id="6ThBXeA" name="part.info.nfc.write.overwrite_warning">
+    <unit id="EhUFVRB" name="part.info.nfc.write.overwrite_confirmation">
       <segment state="translated">
-        <source>part.info.nfc.write.overwrite_warning</source>
-        <target>This tag already contains data. Confirm overwrite, then tap the tag again.</target>
+        <source>part.info.nfc.write.overwrite_confirmation</source>
+        <target>Writing without overwriting was not allowed. The tag may already contain data. Continuing may replace its contents.</target>
       </segment>
     </unit>
     <unit id="5Co0Lnr" name="part.info.nfc.write.permission_denied">
       <segment state="translated">
         <source>part.info.nfc.write.permission_denied</source>
         <target>NFC permission was denied.</target>
+      </segment>
+    </unit>
+    <unit id="NxeBStS" name="part.info.nfc.write.not_allowed">
+      <segment state="translated">
+        <source>part.info.nfc.write.not_allowed</source>
+        <target>NFC writing was not allowed. Check browser permission and whether the tag is writable.</target>
       </segment>
     </unit>
     <unit id="rxgFlUR" name="part.info.nfc.write.unsupported_tag">

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -921,6 +921,42 @@ Sub elements will be moved upwards.</target>
         <target>Select source</target>
       </segment>
     </unit>
+    <unit id="mbvcsWz" name="label_scanner.nfc.scan">
+      <segment state="translated">
+        <source>label_scanner.nfc.scan</source>
+        <target>Scan NFC tag</target>
+      </segment>
+    </unit>
+    <unit id="H7U.MIF" name="label_scanner.nfc.waiting">
+      <segment state="translated">
+        <source>label_scanner.nfc.waiting</source>
+        <target>Hold an NFC tag near your device…</target>
+      </segment>
+    </unit>
+    <unit id="dLiwEQc" name="label_scanner.nfc.read_error">
+      <segment state="translated">
+        <source>label_scanner.nfc.read_error</source>
+        <target>The NFC tag could not be read. Try again.</target>
+      </segment>
+    </unit>
+    <unit id="uZF5m.B" name="label_scanner.nfc.unsupported_record">
+      <segment state="translated">
+        <source>label_scanner.nfc.unsupported_record</source>
+        <target>The tag contains no supported URL or text record.</target>
+      </segment>
+    </unit>
+    <unit id="03ArgJn" name="label_scanner.nfc.permission_denied">
+      <segment state="translated">
+        <source>label_scanner.nfc.permission_denied</source>
+        <target>NFC permission was denied.</target>
+      </segment>
+    </unit>
+    <unit id="426q2AX" name="label_scanner.nfc.failed">
+      <segment state="translated">
+        <source>label_scanner.nfc.failed</source>
+        <target>NFC scanning could not be started. Check that NFC is enabled.</target>
+      </segment>
+    </unit>
     <unit id="melYYg5" name="log.list.title">
       <segment state="final">
         <source>log.list.title</source>
@@ -7138,6 +7174,60 @@ Element 1 -&gt; Element 1.2</target>
       <segment state="translated">
         <source>part.info.add_part_to_project</source>
         <target>Add this [part] to a [project]</target>
+      </segment>
+    </unit>
+    <unit id="394UMjt" name="part.info.nfc.write.button">
+      <segment state="translated">
+        <source>part.info.nfc.write.button</source>
+        <target>Write NFC tag</target>
+      </segment>
+    </unit>
+    <unit id="6vBfGQ5" name="part.info.nfc.write.overwrite_button">
+      <segment state="translated">
+        <source>part.info.nfc.write.overwrite_button</source>
+        <target>Confirm overwrite</target>
+      </segment>
+    </unit>
+    <unit id="b4fnJiH" name="part.info.nfc.write.waiting">
+      <segment state="translated">
+        <source>part.info.nfc.write.waiting</source>
+        <target>Hold the sticker near your device until writing completes…</target>
+      </segment>
+    </unit>
+    <unit id="_1MIW9x" name="part.info.nfc.write.success">
+      <segment state="translated">
+        <source>part.info.nfc.write.success</source>
+        <target>The NFC sticker was enrolled successfully.</target>
+      </segment>
+    </unit>
+    <unit id="6ThBXeA" name="part.info.nfc.write.overwrite_warning">
+      <segment state="translated">
+        <source>part.info.nfc.write.overwrite_warning</source>
+        <target>This tag already contains data. Confirm overwrite, then tap the tag again.</target>
+      </segment>
+    </unit>
+    <unit id="5Co0Lnr" name="part.info.nfc.write.permission_denied">
+      <segment state="translated">
+        <source>part.info.nfc.write.permission_denied</source>
+        <target>NFC permission was denied.</target>
+      </segment>
+    </unit>
+    <unit id="rxgFlUR" name="part.info.nfc.write.unsupported_tag">
+      <segment state="translated">
+        <source>part.info.nfc.write.unsupported_tag</source>
+        <target>This tag is read-only or does not support writable NDEF data.</target>
+      </segment>
+    </unit>
+    <unit id="hB.qnnu" name="part.info.nfc.write.failed">
+      <segment state="translated">
+        <source>part.info.nfc.write.failed</source>
+        <target>The tag could not be written. Check its capacity and try again.</target>
+      </segment>
+    </unit>
+    <unit id="RdSRZLP" name="part.info.nfc.write.cancelled">
+      <segment state="translated">
+        <source>part.info.nfc.write.cancelled</source>
+        <target>NFC writing was cancelled.</target>
       </segment>
     </unit>
     <unit id="5r.n1zf" name="project_bom_entry.label">
@@ -14260,51 +14350,6 @@ Buerklin-API Authentication server:
         <source>oauth_clients.updated</source>
         <target>OAuth2 client updated successfully!</target>
       </segment>
-    </unit>
-    <unit id="nfcScanButton" name="label_scanner.nfc.scan">
-      <segment state="translated"><source>label_scanner.nfc.scan</source><target>Scan NFC tag</target></segment>
-    </unit>
-    <unit id="nfcScanWaiting" name="label_scanner.nfc.waiting">
-      <segment state="translated"><source>label_scanner.nfc.waiting</source><target>Hold an NFC tag near your device…</target></segment>
-    </unit>
-    <unit id="nfcScanReadError" name="label_scanner.nfc.read_error">
-      <segment state="translated"><source>label_scanner.nfc.read_error</source><target>The NFC tag could not be read. Try again.</target></segment>
-    </unit>
-    <unit id="nfcScanUnsupportedRecord" name="label_scanner.nfc.unsupported_record">
-      <segment state="translated"><source>label_scanner.nfc.unsupported_record</source><target>The tag contains no supported URL or text record.</target></segment>
-    </unit>
-    <unit id="nfcScanPermissionDenied" name="label_scanner.nfc.permission_denied">
-      <segment state="translated"><source>label_scanner.nfc.permission_denied</source><target>NFC permission was denied.</target></segment>
-    </unit>
-    <unit id="nfcScanFailed" name="label_scanner.nfc.failed">
-      <segment state="translated"><source>label_scanner.nfc.failed</source><target>NFC scanning could not be started. Check that NFC is enabled.</target></segment>
-    </unit>
-    <unit id="nfcWriteButton" name="nfc.write.button">
-      <segment state="translated"><source>nfc.write.button</source><target>Write NFC tag</target></segment>
-    </unit>
-    <unit id="nfcWriteOverwriteButton" name="nfc.write.overwrite_button">
-      <segment state="translated"><source>nfc.write.overwrite_button</source><target>Confirm overwrite</target></segment>
-    </unit>
-    <unit id="nfcWriteWaiting" name="nfc.write.waiting">
-      <segment state="translated"><source>nfc.write.waiting</source><target>Hold the sticker near your device until writing completes…</target></segment>
-    </unit>
-    <unit id="nfcWriteSuccess" name="nfc.write.success">
-      <segment state="translated"><source>nfc.write.success</source><target>The NFC sticker was enrolled successfully.</target></segment>
-    </unit>
-    <unit id="nfcWriteOverwriteWarning" name="nfc.write.overwrite_warning">
-      <segment state="translated"><source>nfc.write.overwrite_warning</source><target>This tag already contains data. Confirm overwrite, then tap the tag again.</target></segment>
-    </unit>
-    <unit id="nfcWritePermissionDenied" name="nfc.write.permission_denied">
-      <segment state="translated"><source>nfc.write.permission_denied</source><target>NFC permission was denied.</target></segment>
-    </unit>
-    <unit id="nfcWriteUnsupportedTag" name="nfc.write.unsupported_tag">
-      <segment state="translated"><source>nfc.write.unsupported_tag</source><target>This tag is read-only or does not support writable NDEF data.</target></segment>
-    </unit>
-    <unit id="nfcWriteFailed" name="nfc.write.failed">
-      <segment state="translated"><source>nfc.write.failed</source><target>The tag could not be written. Check its capacity and try again.</target></segment>
-    </unit>
-    <unit id="nfcWriteCancelled" name="nfc.write.cancelled">
-      <segment state="translated"><source>nfc.write.cancelled</source><target>NFC writing was cancelled.</target></segment>
     </unit>
   </file>
 </xliff>


### PR DESCRIPTION
- Add NFC scanning to the existing barcode scanner page
- Add NFC tag writing to the part tools section
- Protect existing tag contents by default and require explicit overwrite confirmation
- Hide NFC controls on unsupported or insecure clients

Web NFC currently only works on Chrome on Android  when served over HTTPS.
