### PR TITLE
Move stock to new location

### DIFF
--- a/assets/controllers/pages/part_withdraw_modal_controller.js
+++ b/assets/controllers/pages/part_withdraw_modal_controller.js
@@ -6,6 +6,10 @@ export default class extends Controller
     connect() {
         this.element.addEventListener('show.bs.modal', event => this._handleModalOpen(event));
         this.element.addEventListener('shown.bs.modal', event => this._handleModalShown(event));
+        const newLotRadio = this.element.querySelector('input[name="target_id"][value="new"]');
+        if (newLotRadio) {
+            newLotRadio.addEventListener('change', () => this._toggleNewLotLocation(newLotRadio));
+        }
     }
 
     _handleModalOpen(event) {
@@ -39,6 +43,7 @@ export default class extends Controller
 
         //Hide the move to lot select, if the action is not move (and unhide it, if it is)
         const moveToLotSelect = this.element.querySelector('#withdraw-modal-move-to');
+        const newLotRadio = this.element.querySelector('input[name="target_id"][value="new"]');
         if (action === 'move') {
             moveToLotSelect.classList.remove('d-none');
         } else {
@@ -51,9 +56,14 @@ export default class extends Controller
         moveToLotOptions.forEach(option => {
             if (option.getAttribute('value') === lotID) {
                 option.parentElement.classList.add('d-none');
-                option.selected = false;
+                option.checked = false;
             }
         });
+
+        if (newLotRadio) {
+            newLotRadio.checked = false;
+            this._toggleNewLotLocation(newLotRadio);
+        }
 
         //For adding parts there is no limit on the amount to add
         if (action == 'add') {
@@ -65,5 +75,18 @@ export default class extends Controller
 
     _handleModalShown(event) {
         this.element.querySelector('input[name="amount"]').focus();
+    }
+
+    _toggleNewLotLocation(newLotRadio) {
+        const newLotLocation = this.element.querySelector('#withdraw-modal-new-lot-location');
+        if (!newLotLocation) {
+            return;
+        }
+
+        newLotLocation.classList.toggle('d-none', !newLotRadio.checked);
+        const locationInput = newLotLocation.querySelector('select, input');
+        if (locationInput) {
+            locationInput.required = newLotRadio.checked;
+        }
     }
 }

--- a/assets/controllers/pages/part_withdraw_modal_controller.js
+++ b/assets/controllers/pages/part_withdraw_modal_controller.js
@@ -8,7 +8,10 @@ export default class extends Controller
         this.element.addEventListener('shown.bs.modal', event => this._handleModalShown(event));
         const newLotRadio = this.element.querySelector('input[name="target_id"][value="new"]');
         if (newLotRadio) {
-            newLotRadio.addEventListener('change', () => this._toggleNewLotLocation(newLotRadio));
+            //Any radio in the group can toggle the "new" radio off, so listen on all of them
+            this.element.querySelectorAll('input[name="target_id"]').forEach(radio => {
+                radio.addEventListener('change', () => this._toggleNewLotLocation(newLotRadio));
+            });
         }
     }
 

--- a/src/Controller/PartController.php
+++ b/src/Controller/PartController.php
@@ -131,13 +131,24 @@ final class PartController extends AbstractController
 
         // Build the add-lot form for the INFO page modal (only when not in time-travel mode)
         $addLotForm = null;
-        if ($timeTravel_timestamp === null && $this->isGranted('edit', $part)) {
+        $moveNewLotForm = null;
+        if ($timeTravel_timestamp === null) {
             $newLot = new PartLot();
             $newLot->setPart($part);
-            $addLotForm = $this->createForm(PartLotType::class, $newLot, [
-                'measurement_unit' => $part->getPartUnit(),
-                'action' => $this->generateUrl('part_lot_add', ['id' => $part->getID()]),
-            ]);
+            if ($this->isGranted('edit', $part)) {
+                $addLotForm = $this->createForm(PartLotType::class, $newLot, [
+                    'measurement_unit' => $part->getPartUnit(),
+                    'action' => $this->generateUrl('part_lot_add', ['id' => $part->getID()]),
+                ]);
+            }
+
+            if ($this->isGranted('create', $newLot) && $this->isGranted('move', $newLot)) {
+                $moveNewLotForm = $this->createForm(PartLotType::class, $newLot, [
+                    'measurement_unit' => $part->getPartUnit(),
+                    //CSRF is already covered by the outer withdraw/move form's token
+                    'csrf_protection' => false,
+                ]);
+            }
         }
 
         return $this->render(
@@ -153,6 +164,7 @@ final class PartController extends AbstractController
                 'withdraw_add_helper' => $withdrawAddHelper,
                 'highlightLotId' => $request->query->getInt('highlightLot', 0),
                 'add_lot_form' => $addLotForm,
+                'move_new_lot_form' => $moveNewLotForm,
             ]
         );
     }
@@ -643,7 +655,26 @@ final class PartController extends AbstractController
                         break;
                     case "move":
                         $this->denyAccessUnlessGranted('move', $partLot);
-                        $this->denyAccessUnlessGranted('move', $targetLot);
+                        if ($targetId === 'new') {
+                            $targetLot = new PartLot();
+                            $targetLot->setPart($part);
+                            $this->denyAccessUnlessGranted('create', $targetLot);
+
+                            $newLotForm = $this->createForm(PartLotType::class, $targetLot, [
+                                'measurement_unit' => $part->getPartUnit(),
+                                //CSRF is already covered by the outer withdraw/move form's token
+                                'csrf_protection' => false,
+                            ]);
+                            $newLotForm->handleRequest($request);
+                            if (!$newLotForm->isSubmitted() || !$newLotForm->isValid() || !$targetLot->getStorageLocation()) {
+                                $this->addFlash('error', 'part.created_flash.invalid');
+                                goto err;
+                            }
+
+                            $em->persist($targetLot);
+                        } else {
+                            $this->denyAccessUnlessGranted('move', $targetLot);
+                        }
                         $withdrawAddHelper->move($partLot, $targetLot, $amount, $comment, $timestamp, $delete_lot_if_empty);
                         break;
                     default:

--- a/templates/parts/info/_part_lots.html.twig
+++ b/templates/parts/info/_part_lots.html.twig
@@ -93,7 +93,7 @@
                         <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#withdraw-modal"
                                 data-action="move" data-lot-id="{{ lot.id }}" data-lot-amount="{{ lot.amount }}"
                                 title="{% trans %}part.info.withdraw_modal.title.move{% endtrans %}"
-                                {% if not is_granted('move', lot) or not withdraw_add_helper.canWithdraw(lot) or part.partLots.count == 1 %}disabled{% endif %}
+                                {% if not is_granted('move', lot) or not withdraw_add_helper.canWithdraw(lot) %}disabled{% endif %}
                         >
                             <i class="fa-solid fa-right-left fa-fw"></i>
                         </button>

--- a/templates/parts/info/_withdraw_modal.html.twig
+++ b/templates/parts/info/_withdraw_modal.html.twig
@@ -1,4 +1,7 @@
 <div class="modal fade" id="withdraw-modal" tabindex="-1" aria-labelledby="withdraw-modal-title" aria-hidden="true" {{ stimulus_controller('pages/part_withdraw_modal') }}>
+    {% if move_new_lot_form is not null %}
+        {% form_theme move_new_lot_form 'form/extended_bootstrap_layout.html.twig' %}
+    {% endif %}
     <form method="post" action="{{ path('part_add_withdraw', {"id": part.id}) }}">
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
@@ -38,6 +41,17 @@
                                     </label>
                                 </div>
                             {% endfor %}
+                            {% if move_new_lot_form is not null %}
+                                <div class="form-check">
+                                    <input class="form-check-input" type="radio" name="target_id" value="new" id="modal_target_radio_new" required>
+                                    <label class="form-check-label" for="modal_target_radio_new">
+                                        {% trans %}part_lot.create{% endtrans %}
+                                    </label>
+                                </div>
+                                <div class="mt-2 d-none" id="withdraw-modal-new-lot-location">
+                                    {{ form_row(move_new_lot_form.storage_location) }}
+                                </div>
+                            {% endif %}
                         </div>
                     </div>
 


### PR DESCRIPTION
This addresses Discussion #1247 to make stock management much simpler.
<img width="997" height="705" alt="image" src="https://github.com/user-attachments/assets/561c82e2-9f75-468c-8526-e36921f36f33" />
There is now an added radio button to "add stock" (using the same translation attribute as the "Add stock" button on the main page) that when selected allows the user to choose a location to move stock to, and creates a new stock lot when submitted.

The move lot button is now active on any stock lot that has non-zero quantity, as now there is functionality for parts that only have one stock lot. 