### PR TITLE
Fix stuck submit in withdraw/add-to-lot modal when target_id radios a…

### DIFF
--- a/assets/controllers/pages/part_withdraw_modal_controller.js
+++ b/assets/controllers/pages/part_withdraw_modal_controller.js
@@ -53,6 +53,12 @@ export default class extends Controller
             moveToLotSelect.classList.add('d-none');
         }
 
+        //The target_id radios are only relevant (and must only be required) when the move-to section is shown,
+        //otherwise a hidden but unchecked required radio group can block form submission
+        moveToLotSelect.querySelectorAll('input[name="target_id"]').forEach(radio => {
+            radio.required = action === 'move';
+        });
+
         //First unhide all move to lot options and then hide the currently selected lot
         const moveToLotOptions = moveToLotSelect.querySelectorAll('input[type="radio"]');
         moveToLotOptions.forEach(option => option.parentElement.classList.remove('d-none'));


### PR DESCRIPTION
…re hidden

The move-to-lot radio group (name="target_id") stayed marked required even while its container was hidden for the withdraw/add actions. When none of those hidden radios ended up checked (e.g. only a single lot exists, or the lot being acted on was the only pre-checked option), the browser blocked submission with a hidden, unfocusable invalid control instead of submitting the form.

Toggle the required attribute on the target_id radios together with the move-to section's visibility, so they are only required when the "move" action actually shows them.

Fixes #1510