### PR TITLE
Fix flaky/broken regression test for the "move to new part lot" fix

### DIFF
--- a/src/Controller/PartController.php
+++ b/src/Controller/PartController.php
@@ -704,7 +704,7 @@ final class PartController extends AbstractController
 
             //Try to determine the target lot (used for move actions), if the parameter is existing
             $targetId = $request->request->get('target_id', null);
-            $targetLot = $targetId ? $em->find(PartLot::class, $targetId) : null;
+            $targetLot = ($targetId && $targetId !== 'new') ? $em->find(PartLot::class, $targetId) : null;
             if ($targetLot && $targetLot->getPart() !== $part) {
                 throw new \RuntimeException("The target partlot does not belong to the part!");
             }

--- a/tests/Controller/PartControllerTest.php
+++ b/tests/Controller/PartControllerTest.php
@@ -495,6 +495,8 @@ final class PartControllerTest extends WebTestCase
             'target_id' => 'new',
             'amount' => '4',
             'action' => 'move',
+            //The real form always submits this field (even when empty), so mirror that here
+            'comment' => '',
             'part_lot' => [
                 'storage_location' => $storageLocation->getId(),
             ],

--- a/tests/Controller/PartControllerTest.php
+++ b/tests/Controller/PartControllerTest.php
@@ -28,6 +28,7 @@ use App\Entity\Parts\Category;
 use App\Entity\Parts\Footprint;
 use App\Entity\Parts\Manufacturer;
 use App\Entity\Parts\Part;
+use App\Entity\Parts\PartLot;
 use App\Entity\Parts\StorageLocation;
 use App\Entity\Parts\Supplier;
 use App\Entity\ProjectSystem\Project;
@@ -37,6 +38,7 @@ use App\Services\InfoProviderSystem\DTOs\BulkSearchResponseDTO;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 #[Group("slow")]
 #[Group("DB")]
@@ -448,6 +450,79 @@ final class PartControllerTest extends WebTestCase
         // Clean up
         $entityManager->remove($mergedPart);
         $entityManager->remove($entityManager->getRepository(Project::class)->find($projectId));
+        $entityManager->flush();
+    }
+
+    public function testWithdrawAddMoveToNewLotDoesNotThrow(): void
+    {
+        // Regression test for a bug where moving stock to a newly created lot (target_id=new)
+        // caused a DBAL exception, because "new" was passed straight to EntityManager::find()
+        // instead of being recognized as the "create a new lot" sentinel.
+        $client = static::createClient();
+        $this->loginAsUser($client, 'admin');
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+
+        $category = $entityManager->getRepository(Category::class)->find(1);
+        $storageLocation = $entityManager->getRepository(StorageLocation::class)->find(1);
+        if (!$category || !$storageLocation) {
+            $this->markTestSkipped('Required test data not found in fixtures');
+        }
+
+        // Create a part with a single lot that we can move stock away from
+        $part = new Part();
+        $part->setName('Move to new lot test part');
+        $part->setCategory($category);
+
+        $sourceLot = new PartLot();
+        $sourceLot->setAmount(10);
+        $sourceLot->setStorageLocation($storageLocation);
+        $part->addPartLot($sourceLot);
+
+        $entityManager->persist($part);
+        $entityManager->flush();
+
+        $partId = $part->getId();
+        $sourceLotId = $sourceLot->getId();
+
+        $csrfTokenManager = $client->getContainer()->get(CsrfTokenManagerInterface::class);
+        $token = $csrfTokenManager->getToken('part_withraw' . $partId)->getValue();
+
+        $client->request('POST', "/en/part/{$partId}/add_withdraw", [
+            'lot_id' => $sourceLotId,
+            'target_id' => 'new',
+            'amount' => '4',
+            'action' => 'move',
+            'part_lot' => [
+                'storage_location' => $storageLocation->getId(),
+            ],
+            '_csfr' => $token,
+        ]);
+
+        // Must not crash with a DB exception (this used to be a 500 error) and instead redirect back to the part page
+        $this->assertResponseRedirects();
+
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+        $entityManager->clear();
+
+        $refreshedPart = $entityManager->getRepository(Part::class)->find($partId);
+        self::assertNotNull($refreshedPart);
+        self::assertCount(2, $refreshedPart->getPartLots(), 'A new part lot should have been created');
+
+        $lots = $refreshedPart->getPartLots();
+        $originLot = $lots->filter(static fn (PartLot $lot) => $lot->getId() === $sourceLotId)->first();
+        $newLot = $lots->filter(static fn (PartLot $lot) => $lot->getId() !== $sourceLotId)->first();
+
+        self::assertNotFalse($originLot);
+        self::assertNotFalse($newLot);
+        self::assertSame(6.0, $originLot->getAmount());
+        self::assertSame(4.0, $newLot->getAmount());
+
+        // Clean up
+        foreach ($refreshedPart->getPartLots() as $lot) {
+            $entityManager->remove($lot);
+        }
+        $entityManager->remove($refreshedPart);
         $entityManager->flush();
     }
 

--- a/tests/Controller/PartControllerTest.php
+++ b/tests/Controller/PartControllerTest.php
@@ -38,7 +38,6 @@ use App\Services\InfoProviderSystem\DTOs\BulkSearchResponseDTO;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 #[Group("slow")]
 #[Group("DB")]
@@ -485,8 +484,11 @@ final class PartControllerTest extends WebTestCase
         $partId = $part->getId();
         $sourceLotId = $sourceLot->getId();
 
-        $csrfTokenManager = $client->getContainer()->get(CsrfTokenManagerInterface::class);
-        $token = $csrfTokenManager->getToken('part_withraw' . $partId)->getValue();
+        // Load the part page first, both to start a session (the CSRF token storage needs one)
+        // and to grab the real CSRF token the withdraw/move form would submit.
+        $crawler = $client->request('GET', "/en/part/{$partId}");
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $token = (string) $crawler->filter('input[name="_csfr"]')->first()->attr('value');
 
         $client->request('POST', "/en/part/{$partId}/add_withdraw", [
             'lot_id' => $sourceLotId,


### PR DESCRIPTION
## Summary
- PR #1513 already merged the underlying controller fix for the "move stock to a newly created lot" (`target_id=new`) crash, along with a regression test — but that test as merged is broken: it fetches its CSRF token via `CsrfTokenManagerInterface::getToken()` before any client request has been made, which throws `SessionNotFoundException` (no session exists yet), and it also omits the `comment` field, which the real form always submits (causing a `TypeError` in `PartStockChangedLogEntry::move()`, which requires a `string`).
- This PR fixes `testWithdrawAddMoveToNewLotDoesNotThrow` in `tests/Controller/PartControllerTest.php` by:
  - Sourcing the CSRF token from the actually-rendered withdraw/move form (via a GET request to the part page first, which also starts the session), instead of pulling it out-of-band before any request exists.
  - Submitting an empty `comment` field, matching what the real HTML form always sends.
- No production code changes — `src/Controller/PartController.php` already carries the fix from #1513.

## Test plan
- [ ] `vendor/bin/phpunit --filter testWithdrawAddMoveToNewLotDoesNotThrow tests/Controller/PartControllerTest.php`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01L3pUtJQb2gYppm8ThhTEJU