### PR TITLE
Support 0 Ω resistor values in the component image generator

### DIFF
--- a/assets/controllers/pages/component_image_generator_controller.js
+++ b/assets/controllers/pages/component_image_generator_controller.js
@@ -72,6 +72,7 @@ const RESISTOR_POWERS = {
     "0.5": {label: "1/2 W", len: 9.0, dia: 3.2, pitch: 12.7, pitchIn: "0.5\""},
     "1": {label: "1 W", len: 11.5, dia: 4.5, pitch: 15.24, pitchIn: "0.6\""},
     "2": {label: "2 W", len: 15.5, dia: 5.0, pitch: 20.32, pitchIn: "0.8\""},
+    "5": {label: "5 W", len: 32.0, dia: 9.5, pitch: 40.0, pitchIn: "1.6\""},
 };
 
 // Standard SMD (chip) packages: imperial code -> metric code, size (mm), power (W).
@@ -495,7 +496,7 @@ export default class extends Controller {
         const current = this.computeResistance();
         this.bandCount = parseInt(event.target.value, 10);
         this.renderBandSelects();
-        if (current && current.ohms > 0) {
+        if (current && current.ohms >= 0) {
             this.setBandsFromValue(current.ohms, current.tolerance);
         }
         this.updateResistor();
@@ -651,17 +652,24 @@ export default class extends Controller {
      * them into the selects.
      */
     setBandsFromValue(value, tolerance, target = this.bandSelectsTarget, count = this.bandCount) {
-        if (!(value > 0)) {
+        if (!(value >= 0)) {
             return false;
         }
         const numDigits = count === 4 ? 2 : 3;
 
-        // Normalize the value into <numDigits> significant figures + power of ten
-        let exp = Math.floor(Math.log10(value)) - (numDigits - 1);
-        let digits = Math.round(value / Math.pow(10, exp));
-        if (digits >= Math.pow(10, numDigits)) {
-            digits = Math.round(digits / 10);
-            exp += 1;
+        let exp, digits;
+        if (value === 0) {
+            // 0 Ω "jumper" resistor: every digit band and the multiplier band are black.
+            exp = 0;
+            digits = 0;
+        } else {
+            // Normalize the value into <numDigits> significant figures + power of ten
+            exp = Math.floor(Math.log10(value)) - (numDigits - 1);
+            digits = Math.round(value / Math.pow(10, exp));
+            if (digits >= Math.pow(10, numDigits)) {
+                digits = Math.round(digits / 10);
+                exp += 1;
+            }
         }
         const multiplier = Math.pow(10, exp);
 
@@ -750,7 +758,7 @@ export default class extends Controller {
     applyResistorValue() {
         const raw = this.resistorValueInputTarget.value;
         const ohms = this.parseValue(raw, "R");
-        if (ohms === null || !(ohms > 0)) {
+        if (ohms === null || !(ohms >= 0)) {
             this.resistorValueInputTarget.classList.add("is-invalid");
             return;
         }
@@ -1766,7 +1774,7 @@ export default class extends Controller {
         const field = event.currentTarget.dataset.field;
         const raw = event.currentTarget.value;
         const ohms = field === "value" ? this.parseValue(raw, "R") : this.smdCodeToOhms(raw);
-        if (ohms === null || !(ohms > 0)) {
+        if (ohms === null || !(ohms >= 0)) {
             event.currentTarget.classList.add("is-invalid");
             this.smdOhms = null;
             if (this.hasSmdResultTarget) {
@@ -1809,7 +1817,7 @@ export default class extends Controller {
 
     /** Draws the SMD chip using the marking currently selected as "printed on the part". */
     redrawSmd() {
-        if (this.smdOhms === null || this.smdOhms === undefined || !(this.smdOhms > 0)) {
+        if (this.smdOhms === null || this.smdOhms === undefined || !(this.smdOhms >= 0)) {
             return;
         }
         const codes = {
@@ -1877,8 +1885,12 @@ export default class extends Controller {
 
     /** ohms -> 4-digit precision code (3 significant figures), R-notation below 100 Ω. */
     ohmsTo4Digit(ohms) {
-        if (!(ohms > 0)) {
+        if (!(ohms >= 0)) {
             return null;
+        }
+        if (ohms === 0) {
+            // Standard "0 Ω jumper" marking.
+            return "0000";
         }
         if (ohms < 100) {
             let s = parseFloat(ohms.toPrecision(3)).toString();
@@ -1901,7 +1913,7 @@ export default class extends Controller {
 
     /** ohms -> EIA-96 code (value code + multiplier letter) for E96 values, else null. */
     ohmsToEia96(ohms) {
-        if (!(ohms > 0)) {
+        if (!(ohms >= 0)) {
             return null;
         }
         const order = ["A", "B", "C", "D", "E", "F", "X", "S", "Y", "R", "Z"];
@@ -1938,8 +1950,12 @@ export default class extends Controller {
      * Returns null when the value is out of the representable range.
      */
     ohmsToSmdCode(ohms) {
-        if (!(ohms > 0)) {
+        if (!(ohms >= 0)) {
             return null;
+        }
+        if (ohms === 0) {
+            // Standard "0 Ω jumper" marking.
+            return "000";
         }
         if (ohms < 10) {
             let s = parseFloat(ohms.toFixed(2)).toString();
@@ -2000,7 +2016,7 @@ export default class extends Controller {
             + this.dimV(bodyY, bodyBottom, bodyX + bodyW + 16, `W ${this.formatMm(pkg.w)}`, bodyX + bodyW);
 
         //The chip itself shows the printed code; print the decoded value (+ tolerance) as a caption below.
-        const valueLabel = this.smdOhms > 0 ? this.formatOhms(this.smdOhms) + this.specSuffix(spec) : "";
+        const valueLabel = this.smdOhms >= 0 ? this.formatOhms(this.smdOhms) + this.specSuffix(spec) : "";
         const h = bodyBottom + 54;
         const valueCaption = valueLabel
             ? `<text x="${cx}" y="${h - 12}" text-anchor="middle" font-family="monospace" font-size="16" font-weight="700" fill="#3a4149">${valueLabel}</text>`

--- a/src/Services/Tools/ComponentValueGuesser.php
+++ b/src/Services/Tools/ComponentValueGuesser.php
@@ -193,7 +193,7 @@ final readonly class ComponentValueGuesser
         $tolerance = $this->detectTolerance($part);
         $color = $this->detectBodyColor($part);
 
-        if ($ohms !== null && $ohms > 0) {
+        if ($ohms !== null && $ohms >= 0) {
             $package = $this->detectSmdPackage($part);
 
             return [
@@ -626,7 +626,8 @@ final readonly class ComponentValueGuesser
             }
 
             $num = $param->getValueTypical();
-            if ($num === null || $num <= 0) {
+            //0 Ω is a real value (a "jumper" resistor); 0 F / 0 H are not, so only resistors allow it.
+            if ($num === null || $num < 0 || ($num === 0.0 && !$isRes)) {
                 continue;
             }
 

--- a/templates/tools/component_image_generator/_calculator_body.html.twig
+++ b/templates/tools/component_image_generator/_calculator_body.html.twig
@@ -102,6 +102,7 @@
                                             <option value="0.5">1/2 W</option>
                                             <option value="1">1 W</option>
                                             <option value="2">2 W</option>
+                                            <option value="5">5 W</option>
                                         </select>
                                     </div>
                                 </div>

--- a/tests/Services/Tools/ComponentValueGuesserTest.php
+++ b/tests/Services/Tools/ComponentValueGuesserTest.php
@@ -174,6 +174,41 @@ class ComponentValueGuesserTest extends TestCase
         self::assertNull($this->guesser->guess($this->part('Arduino Uno R3 development board')));
     }
 
+    public function testClassifiesZeroOhmJumperResistor(): void
+    {
+        $guess = $this->guesser->guess($this->part('Resistor 0R jumper'));
+        self::assertNotNull($guess);
+        self::assertSame('resistor', $guess['type']);
+        self::assertSame(0.0, $guess['value']);
+    }
+
+    public function testClassifiesZeroOhmSmdJumperFromPackage(): void
+    {
+        $guess = $this->guesser->guess($this->part('Resistor 0R 0805 jumper SMD'));
+        self::assertNotNull($guess);
+        self::assertSame('smd_resistor', $guess['type']);
+        self::assertSame('0805', $guess['package']);
+        self::assertSame(0.0, $guess['value']);
+    }
+
+    public function testZeroOhmFromResistanceParameter(): void
+    {
+        $part = $this->partWithParameter('Resistance', 0.0, 'Ω');
+        [$ohms, $farads] = $this->guesser->extractValue($part);
+        self::assertNull($farads);
+        self::assertSame(0.0, $ohms);
+    }
+
+    public function testZeroCapacitanceParameterIsIgnored(): void
+    {
+        // Unlike 0 Ω (a real "jumper" resistor), 0 F isn't a real capacitor value, so it
+        // shouldn't be picked up as a classification.
+        $part = $this->partWithParameter('Capacitance', 0.0, 'nF');
+        [$ohms, $farads] = $this->guesser->extractValue($part);
+        self::assertNull($ohms);
+        self::assertNull($farads);
+    }
+
     /**
      * @dataProvider powerProvider
      */


### PR DESCRIPTION
Entering "0" (or a 0R/0805 jumper part) was rejected everywhere the
calculator checked `value > 0`, even though 0 Ω "jumper" resistors are
a real, standard part. Zero is now accepted for the resistor and SMD
resistor tabs and drawn with the conventional all-black bands /
"000"/"0000" markings; the server-side ComponentValueGuesser now also
classifies parts with a 0 Ω resistance parameter or "0R" name instead
of silently skipping them. Also adds a 5 W resistor power-rating
option, as requested in the same issue.

Fixes #1508