### PR TITLE
Add TrustedParts.com (ECIA) info provider

### DIFF
--- a/docs/usage/information_provider_system.md
+++ b/docs/usage/information_provider_system.md
@@ -331,7 +331,43 @@ Once you have the API key, you can configure the Canopy provider in Part-DB usin
 
 * `PROVIDER_CANOPY_API_KEY`: The API key you got from Canopy (mandatory)
 
+### TrustedParts
 
+The TrustedParts provider uses the [TrustedParts.com Inventory API](https://www.trustedparts.com/en/docs/api/trustedparts-api)
+to search for parts. TrustedParts.com is operated by the Electronic Components Industry Association (ECIA) and
+aggregates the offers (stock and prices) of authorized distributors, similar to Octopart. Besides the offers, it also
+provides specifications for many parts, which Part-DB imports as parameters.
+
+Please note that the TrustedParts API does not return any product images, so parts created with this provider have no
+preview image. You can generate one with the built-in component image generator (the button on the image placeholder of
+the part page), which works well with the package information this provider supplies.
+
+The API is free of charge, but you have to
+[request access](https://www.trustedparts.com/en/docs/api/trustedparts-api/credentials) for it: Register an account on
+TrustedParts.com, verify your mail address and request API access on the "Additional Features" tab of your account.
+After your request was approved, you find the company ID and the API key on the "API Key" tab of the "My Account" page.
+
+Please note the [API terms of use](https://www.trustedparts.com/en/docs/api/trustedparts-api/terms-of-use), especially:
+The data may only be used for internal purchasing decisions, must not be published or resold, has to be attributed to
+TrustedParts.com and must not be cached for longer than one week (Part-DB caches the results for four days at most).
+There are also [rate limits](https://www.trustedparts.com/en/docs/api/trustedparts-api/requests), so you should only
+make as many requests as you actually need.
+
+The following env configuration options are available:
+
+* `PROVIDER_TRUSTEDPARTS_COMPANY_ID`: The company ID of your TrustedParts.com account (mandatory)
+* `PROVIDER_TRUSTEDPARTS_API_KEY`: The API key of your TrustedParts.com account (mandatory)
+* `PROVIDER_TRUSTEDPARTS_CURRENCY`: The currency you want to get prices in if available (optional, 3 letter ISO-code,
+  default: `EUR`). Distributors which do not support the requested currency return their prices in their own currency.
+* `PROVIDER_TRUSTEDPARTS_COUNTRY`: The country you want to get the prices for (optional, 2 letter ISO-code, default: `DE`)
+* `PROVIDER_TRUSTEDPARTS_LANGUAGE`: The language the specifications should be translated to. Possible values: `en`,
+  `de`, `es`, `fr`, `it`, `pt`, `ja` (optional, default: `en`)
+* `PROVIDER_TRUSTEDPARTS_SEARCH_LIMIT`: The maximum number of results to return per search (optional, default: `25`)
+* `PROVIDER_TRUSTEDPARTS_IN_STOCK_ONLY`: If set to `1`, only offers of distributors which currently have the part in
+  stock are returned (optional, default: `0`)
+* `PROVIDER_TRUSTEDPARTS_USE_CACHED_DATA`: If set to `1`, TrustedParts.com answers with cached stock and price data
+  instead of querying the distributors in real time. This is faster and does not count against the rate limits, but the
+  data can be outdated (optional, default: `0`)
 
 ### Custom providers
 

--- a/src/Services/InfoProviderSystem/Providers/TrustedPartsProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/TrustedPartsProvider.php
@@ -1,0 +1,441 @@
+<?php
+/*
+ * This file is part of Part-DB (https://github.com/Part-DB/Part-DB-symfony).
+ *
+ *  Copyright (C) 2019 - 2026 Jan Böhmer (https://github.com/jbtronics)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+
+namespace App\Services\InfoProviderSystem\Providers;
+
+use App\Entity\UserSystem\User;
+use App\Services\InfoProviderSystem\DTOs\FileDTO;
+use App\Services\InfoProviderSystem\DTOs\ParameterDTO;
+use App\Services\InfoProviderSystem\DTOs\PartDetailDTO;
+use App\Services\InfoProviderSystem\DTOs\PriceDTO;
+use App\Services\InfoProviderSystem\DTOs\ProviderInfoDTO;
+use App\Services\InfoProviderSystem\DTOs\PurchaseInfoDTO;
+use App\Settings\InfoProviderSystem\TrustedPartsSettings;
+use Psr\Cache\CacheItemPoolInterface;
+use Shivas\VersioningBundle\Service\VersionManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * This provider uses the TrustedParts.com (ECIA) Inventory API to search for parts and get the offers of the
+ * authorized distributors for them.
+ *
+ * The API does not know any part IDs, parts are always identified by their manufacturer part number (and the
+ * manufacturer name). Therefore, we build our own provider IDs in the form "manufacturer|mpn".
+ * As a single search already returns all information we need (including the offers of all distributors), the results
+ * are cached, so that the detail view does not need to query the API again.
+ */
+class TrustedPartsProvider implements BatchInfoProviderInterface
+{
+    public const PROVIDER_KEY = 'trustedparts';
+
+    private const ENDPOINT_URL = 'https://api.trustedparts.com/v2/search';
+
+    /** @var string The separator used to build the provider ID out of the manufacturer name and the MPN */
+    private const ID_SEPARATOR = '|';
+
+    /** @var int The API rejects requests which contain more than 50 part numbers */
+    private const MAX_QUERIES_PER_REQUEST = 50;
+
+    /**
+     * @var int How long the retrieved parts are cached. The API terms of use allow caching for a maximum of one week.
+     */
+    private const CACHE_TTL = 60 * 60 * 24;
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly TrustedPartsSettings $settings,
+        private readonly CacheItemPoolInterface $partInfoCache,
+        private readonly Security $security,
+        private readonly VersionManagerInterface $versionManager,
+    ) {
+    }
+
+    public function getProviderInfo(): ProviderInfoDTO
+    {
+        return new ProviderInfoDTO(
+            key: self::PROVIDER_KEY,
+            name: 'TrustedParts',
+            description: 'This provider uses the TrustedParts.com (ECIA) API to search for parts and retrieve the offers of authorized distributors.',
+            url: 'https://www.trustedparts.com/',
+            disabledHelp: 'Configure the company ID and the API key in the provider settings to enable.',
+            settingsClass: TrustedPartsSettings::class,
+            capabilities: [
+                ProviderCapabilities::BASIC,
+                ProviderCapabilities::DATASHEET,
+                ProviderCapabilities::PRICE,
+                ProviderCapabilities::FOOTPRINT,
+                ProviderCapabilities::PARAMETERS,
+            ],
+        );
+    }
+
+    public function isActive(): bool
+    {
+        return $this->settings->companyId !== null && $this->settings->companyId !== ''
+            && $this->settings->apiKey !== null && $this->settings->apiKey !== '';
+    }
+
+    public function searchByKeyword(string $keyword, array $options = []): array
+    {
+        $keyword = trim($keyword);
+        //The API requires a search term of at least two characters
+        if (mb_strlen($keyword) < 2) {
+            return [];
+        }
+
+        //Partial matches are only allowed for requests containing a single part number
+        $results = $this->apiSearch([['SearchToken' => $keyword]], false);
+
+        $tmp = [];
+        foreach ($results as $part) {
+            $dto = $this->partResultToDTO($part);
+            //Cache the part, so the details can be shown later without querying the API again
+            $this->saveToCache($dto);
+            $tmp[] = $dto;
+
+            if (count($tmp) >= $this->settings->searchLimit) {
+                break;
+            }
+        }
+
+        return $tmp;
+    }
+
+    public function searchByKeywordsBatch(array $keywords, array $options = []): array
+    {
+        $results = [];
+        $queries = [];
+
+        foreach ($keywords as $keyword) {
+            $results[$keyword] = [];
+
+            //The API requires a search term of at least two characters
+            if (mb_strlen(trim($keyword)) >= 2) {
+                $queries[$keyword] = ['SearchToken' => trim($keyword)];
+            }
+        }
+
+        foreach (array_chunk($queries, self::MAX_QUERIES_PER_REQUEST, true) as $chunk) {
+            //If we search for multiple part numbers at once, only exact matches are possible
+            $parts = $this->apiSearch(array_values($chunk), true);
+
+            //The response does not tell us which query a result belongs to, so we have to match them by part number.
+            //Like the API itself, we ignore punctuation and spacing while doing so.
+            $keywords_by_part_number = [];
+            foreach (array_keys($chunk) as $keyword) {
+                $keywords_by_part_number[$this->normalizePartNumber((string) $keyword)][] = $keyword;
+            }
+
+            foreach ($parts as $part) {
+                $dto = $this->partResultToDTO($part);
+                $this->saveToCache($dto);
+
+                foreach ($keywords_by_part_number[$this->normalizePartNumber($dto->mpn ?? '')] ?? [] as $keyword) {
+                    $results[$keyword][] = $dto;
+                }
+            }
+        }
+
+        return $results;
+    }
+
+    public function getDetails(string $id, array $options = []): PartDetailDTO
+    {
+        $no_cache = $options[self::OPTION_NO_CACHE] ?? false;
+
+        //Normally the part was already retrieved during the search, so we can use the cached version
+        $cached = $no_cache ? null : $this->getFromCache($id);
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        [$manufacturer, $mpn] = $this->splitId($id);
+        if ($mpn === '') {
+            throw new \RuntimeException('Invalid TrustedParts part ID: '.$id);
+        }
+
+        $query = ['SearchToken' => $mpn];
+        if ($manufacturer !== '') {
+            $query['Manufacturers'] = [$manufacturer];
+        }
+
+        $fallback = null;
+        foreach ($this->apiSearch([$query], true) as $part) {
+            $dto = $this->partResultToDTO($part);
+            $this->saveToCache($dto);
+
+            if ($dto->provider_id === $id) {
+                return $dto;
+            }
+
+            //An exact match search also returns parts whose part number only differs in punctuation, so keep the
+            //first result with a matching part number as fallback
+            if ($fallback === null && $this->normalizePartNumber($dto->mpn ?? '') === $this->normalizePartNumber($mpn)) {
+                $fallback = $dto;
+            }
+        }
+
+        return $fallback ?? throw new \RuntimeException('No part found with ID '.$id);
+    }
+
+    /**
+     * Performs a search request against the API and returns the part results of the response.
+     * @param  array<int, array<string, mixed>>  $queries The queries (each containing at least a SearchToken)
+     * @param  bool  $exactMatch Whether only exact matches should be returned
+     * @return array<int, array<string, mixed>>
+     */
+    private function apiSearch(array $queries, bool $exactMatch): array
+    {
+        $response = $this->httpClient->request('POST', self::ENDPOINT_URL, [
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+            'json' => [
+                'CompanyId' => $this->settings->companyId,
+                'ApiKey' => $this->settings->apiKey,
+                'Queries' => $queries,
+                'CountryCode' => $this->settings->country,
+                'CurrencyCode' => $this->settings->currency,
+                'LanguageCode' => $this->settings->language,
+                'InStockOnly' => $this->settings->inStockOnly,
+                'ExactMatch' => $exactMatch,
+                'UseCachedData' => $this->settings->useCachedData,
+                //Part-DB is not a website showing the results to an anonymous visitor, so this is never a crawler
+                'IsCrawler' => false,
+                'UserAgent' => $this->buildUserAgent(),
+            ],
+        ]);
+
+        if ($response->getStatusCode() !== 200) {
+            throw new \RuntimeException(sprintf(
+                'TrustedParts API returned HTTP %d: %s',
+                $response->getStatusCode(),
+                $response->getContent(false)
+            ));
+        }
+
+        $data = $response->toArray();
+
+        if (isset($data['ErrorMessage']) && $data['ErrorMessage'] !== '') {
+            throw new \RuntimeException('TrustedParts API returned an error: '.$data['ErrorMessage']);
+        }
+
+        return $data['PartResults'] ?? [];
+    }
+
+    /**
+     * Builds the user agent which is sent with every request.
+     * The API terms of use require that applications which are not a website identify themselves with their name and
+     * a unique user identifier (which must not contain any personally identifiable information).
+     */
+    private function buildUserAgent(): string
+    {
+        $user = $this->security->getUser();
+        $identifier = ($user instanceof User && $user->getID() !== null) ? 'user-'.$user->getID() : 'system';
+
+        return sprintf('Part-DB/%s (%s)', $this->versionManager->getVersion()->toString(), $identifier);
+    }
+
+    /**
+     * Converts a part result of the API response into a PartDetailDTO.
+     * @param  array<string, mixed>  $part
+     */
+    private function partResultToDTO(array $part): PartDetailDTO
+    {
+        $mpn = trim((string) ($part['PartNumber'] ?? ''));
+        $manufacturer = $part['Manufacturer'] ?? null;
+
+        //Parse the specifications
+        $parameters = [];
+        $specifications = [];
+        foreach ($part['Specifications'] ?? [] as $specification) {
+            $name = trim((string) ($specification['Key'] ?? ''));
+            $value = trim((string) ($specification['Value'] ?? ''));
+
+            if ($name === '' || $value === '') {
+                continue;
+            }
+
+            $specifications[$name] = $value;
+            $parameters[] = ParameterDTO::parseValueIncludingUnit(name: $name, value: $value);
+        }
+
+        //Some of the specifications are useful for other fields of the part
+        $footprint = $specifications['Package / Case'] ?? null;
+        $category = null;
+        foreach (['Subcategory', 'Product Type', 'Product'] as $category_key) {
+            if (isset($specifications[$category_key])) {
+                $category = $specifications[$category_key];
+                break;
+            }
+        }
+
+        //Parse the offers of the distributors. The part itself has no description or datasheet, so we take these
+        //from the distributor results too.
+        $description = '';
+        $datasheets = [];
+        $orderinfos = [];
+
+        foreach ($part['Distributors'] ?? [] as $distributor) {
+            $distributor_name = trim((string) ($distributor['Name'] ?? ''));
+
+            foreach ($distributor['DistributorResults'] ?? [] as $offer) {
+                if ($description === '') {
+                    $description = trim((string) ($offer['Description'] ?? ''));
+                }
+
+                $product_url = null;
+                foreach ($offer['Links'] ?? [] as $link) {
+                    $url = trim((string) ($link['Url'] ?? ''));
+                    if ($url === '') {
+                        continue;
+                    }
+
+                    if (strcasecmp((string) ($link['Type'] ?? ''), 'Datasheet') === 0) {
+                        //Every distributor links its own copy of the datasheet, so we name them after the
+                        //distributor. The URL is used as key to filter out duplicates.
+                        $datasheets[$url] = new FileDTO($url,
+                            $distributor_name === '' ? 'Datasheet' : 'Datasheet ('.$distributor_name.')');
+                    } elseif ($product_url === null) {
+                        //The link to the offer is either of type "Buy" (orderable) or "View"
+                        $product_url = $url;
+                    }
+                }
+
+                if ($distributor_name === '') {
+                    continue;
+                }
+
+                $currency = $offer['Pricing']['CurrencyCode'] ?? null;
+                $prices = [];
+                foreach ($offer['Pricing']['Prices'] ?? [] as $price) {
+                    if (!isset($price['Quantity'], $price['Amount'])) {
+                        continue;
+                    }
+
+                    $prices[] = new PriceDTO(
+                        minimum_discount_amount: (float) $price['Quantity'],
+                        price: $this->formatPrice((float) $price['Amount']),
+                        currency_iso_code: $currency,
+                        includes_tax: false,
+                    );
+                }
+
+                //Not every distributor provides a part number for its offers
+                $order_number = trim((string) ($offer['DistributorPartNumber'] ?? ''));
+                if ($order_number === '' || strcasecmp($order_number, 'N/A') === 0) {
+                    $order_number = $mpn;
+                }
+
+                $orderinfos[] = new PurchaseInfoDTO(
+                    distributor_name: $distributor_name,
+                    order_number: $order_number,
+                    prices: $prices,
+                    product_url: $product_url,
+                    prices_include_vat: false,
+                );
+            }
+        }
+
+        return new PartDetailDTO(
+            provider_key: self::PROVIDER_KEY,
+            provider_id: $this->buildId($manufacturer, $mpn),
+            name: $mpn,
+            description: $description,
+            category: $category,
+            manufacturer: $manufacturer,
+            mpn: $mpn,
+            provider_url: $part['ProductUrl'] ?? null,
+            footprint: $footprint,
+            datasheets: array_values($datasheets),
+            parameters: $parameters,
+            vendor_infos: $orderinfos,
+        );
+    }
+
+    /**
+     * Builds the provider ID for the part with the given manufacturer and part number.
+     */
+    private function buildId(?string $manufacturer, string $mpn): string
+    {
+        return ($manufacturer ?? '').self::ID_SEPARATOR.$mpn;
+    }
+
+    /**
+     * Splits a provider ID into the manufacturer name and the part number.
+     * @return array{string, string}
+     */
+    private function splitId(string $id): array
+    {
+        $parts = explode(self::ID_SEPARATOR, $id, 2);
+
+        //IDs without a separator are interpreted as a plain part number
+        if (count($parts) < 2) {
+            return ['', trim($id)];
+        }
+
+        return [trim($parts[0]), trim($parts[1])];
+    }
+
+    /**
+     * Removes everything but letters and digits from a part number, so that part numbers can be compared the same
+     * way the API determines an exact match (e.g. "BAT-54C" is an exact match for "BAT54C").
+     */
+    private function normalizePartNumber(string $part_number): string
+    {
+        return strtoupper(preg_replace('/[^a-zA-Z0-9]/', '', $part_number) ?? '');
+    }
+
+    /**
+     * Formats a price for the PriceDTO. We can not simply cast it to a string, as that could result in a scientific
+     * notation, which can not be parsed as a decimal number.
+     */
+    private function formatPrice(float $price): string
+    {
+        $tmp = rtrim(rtrim(sprintf('%.10F', $price), '0'), '.');
+
+        return $tmp === '' ? '0' : $tmp;
+    }
+
+    private function saveToCache(PartDetailDTO $part): void
+    {
+        $item = $this->partInfoCache->getItem($this->cacheKey($part->provider_id));
+        $item->set($part);
+        $item->expiresAfter(self::CACHE_TTL);
+        $this->partInfoCache->save($item);
+    }
+
+    private function getFromCache(string $id): ?PartDetailDTO
+    {
+        $item = $this->partInfoCache->getItem($this->cacheKey($id));
+
+        return $item->isHit() ? $item->get() : null;
+    }
+
+    private function cacheKey(string $id): string
+    {
+        //The IDs contain characters which are not allowed in cache keys, so we hash them
+        return 'trustedparts_part_'.hash('xxh3', $id);
+    }
+}

--- a/src/Settings/InfoProviderSystem/InfoProviderSettings.php
+++ b/src/Settings/InfoProviderSystem/InfoProviderSettings.php
@@ -82,4 +82,7 @@ class InfoProviderSettings
     #[EmbeddedSettings]
     public ?CanopySettings $canopy = null;
 
+    #[EmbeddedSettings]
+    public ?TrustedPartsSettings $trustedparts = null;
+
 }

--- a/src/Settings/InfoProviderSystem/TrustedPartsSettings.php
+++ b/src/Settings/InfoProviderSystem/TrustedPartsSettings.php
@@ -1,0 +1,96 @@
+<?php
+/*
+ * This file is part of Part-DB (https://github.com/Part-DB/Part-DB-symfony).
+ *
+ *  Copyright (C) 2019 - 2026 Jan Böhmer (https://github.com/jbtronics)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+
+namespace App\Settings\InfoProviderSystem;
+
+use App\Form\Type\APIKeyType;
+use App\Settings\SettingsIcon;
+use Jbtronics\SettingsBundle\Metadata\EnvVarMode;
+use Jbtronics\SettingsBundle\Settings\Settings;
+use Jbtronics\SettingsBundle\Settings\SettingsParameter;
+use Jbtronics\SettingsBundle\Settings\SettingsTrait;
+use Symfony\Component\Form\Extension\Core\Type\CountryType;
+use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
+use Symfony\Component\Form\Extension\Core\Type\LanguageType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Translation\TranslatableMessage as TM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[Settings(label: new TM("settings.ips.trustedparts"), description: new TM("settings.ips.trustedparts.help"))]
+#[SettingsIcon("fa-plug")]
+class TrustedPartsSettings
+{
+    use SettingsTrait;
+
+    /** @var string[] The languages which are supported by the TrustedParts API for specification translations */
+    public const SUPPORTED_LANGUAGES = ["en", "de", "es", "fr", "it", "pt", "ja"];
+
+    #[SettingsParameter(label: new TM("settings.ips.trustedparts.companyId"),
+        description: new TM("settings.ips.trustedparts.companyId.help"),
+        formType: APIKeyType::class, formOptions: ["help_html" => true],
+        envVar: "PROVIDER_TRUSTEDPARTS_COMPANY_ID", envVarMode: EnvVarMode::OVERWRITE)]
+    public ?string $companyId = null;
+
+    #[SettingsParameter(label: new TM("settings.ips.mouser.apiKey"),
+        description: new TM("settings.ips.trustedparts.apiKey.help"),
+        formType: APIKeyType::class, formOptions: ["help_html" => true],
+        envVar: "PROVIDER_TRUSTEDPARTS_API_KEY", envVarMode: EnvVarMode::OVERWRITE)]
+    public ?string $apiKey = null;
+
+    #[SettingsParameter(label: new TM("settings.ips.tme.currency"), formType: CurrencyType::class,
+        formOptions: ["preferred_choices" => ["EUR", "USD", "GBP", "CHF"]],
+        envVar: "PROVIDER_TRUSTEDPARTS_CURRENCY", envVarMode: EnvVarMode::OVERWRITE)]
+    #[Assert\Currency]
+    public string $currency = "EUR";
+
+    #[SettingsParameter(label: new TM("settings.ips.tme.country"), formType: CountryType::class,
+        formOptions: ["preferred_choices" => ["DE", "GB", "FR", "US"]],
+        envVar: "PROVIDER_TRUSTEDPARTS_COUNTRY", envVarMode: EnvVarMode::OVERWRITE)]
+    #[Assert\Country]
+    public string $country = "DE";
+
+    #[SettingsParameter(label: new TM("settings.ips.tme.language"), formType: LanguageType::class,
+        formOptions: ["preferred_choices" => self::SUPPORTED_LANGUAGES],
+        envVar: "PROVIDER_TRUSTEDPARTS_LANGUAGE", envVarMode: EnvVarMode::OVERWRITE)]
+    #[Assert\Language]
+    #[Assert\Choice(choices: self::SUPPORTED_LANGUAGES)]
+    public string $language = "en";
+
+    /** @var int The maximum number of results which are returned by a keyword search */
+    #[SettingsParameter(label: new TM("settings.ips.trustedparts.searchLimit"),
+        description: new TM("settings.ips.trustedparts.searchLimit.help"),
+        formType: NumberType::class, formOptions: ["attr" => ["min" => 1, "max" => 100]],
+        envVar: "int:PROVIDER_TRUSTEDPARTS_SEARCH_LIMIT", envVarMode: EnvVarMode::OVERWRITE)]
+    #[Assert\Range(min: 1, max: 100)]
+    public int $searchLimit = 25;
+
+    #[SettingsParameter(label: new TM("settings.ips.trustedparts.inStockOnly"),
+        description: new TM("settings.ips.trustedparts.inStockOnly.help"),
+        envVar: "bool:PROVIDER_TRUSTEDPARTS_IN_STOCK_ONLY", envVarMode: EnvVarMode::OVERWRITE)]
+    public bool $inStockOnly = false;
+
+    #[SettingsParameter(label: new TM("settings.ips.trustedparts.useCachedData"),
+        description: new TM("settings.ips.trustedparts.useCachedData.help"),
+        envVar: "bool:PROVIDER_TRUSTEDPARTS_USE_CACHED_DATA", envVarMode: EnvVarMode::OVERWRITE)]
+    public bool $useCachedData = false;
+}

--- a/tests/Services/InfoProviderSystem/Providers/TrustedPartsProviderTest.php
+++ b/tests/Services/InfoProviderSystem/Providers/TrustedPartsProviderTest.php
@@ -1,0 +1,375 @@
+<?php
+/*
+ * This file is part of Part-DB (https://github.com/Part-DB/Part-DB-symfony).
+ *
+ *  Copyright (C) 2019 - 2026 Jan Böhmer (https://github.com/jbtronics)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace App\Tests\Services\InfoProviderSystem\Providers;
+
+use App\Services\InfoProviderSystem\DTOs\PartDetailDTO;
+use App\Services\InfoProviderSystem\Providers\ProviderCapabilities;
+use App\Services\InfoProviderSystem\Providers\TrustedPartsProvider;
+use App\Settings\InfoProviderSystem\TrustedPartsSettings;
+use App\Tests\SettingsTestHelper;
+use PHPUnit\Framework\TestCase;
+use Shivas\VersioningBundle\Service\VersionManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Version\Version;
+
+final class TrustedPartsProviderTest extends TestCase
+{
+    private TrustedPartsSettings $settings;
+
+    protected function setUp(): void
+    {
+        $this->settings = SettingsTestHelper::createSettingsDummy(TrustedPartsSettings::class);
+        $this->settings->companyId = 'Test Company';
+        $this->settings->apiKey = 'test-api-key';
+    }
+
+    /**
+     * @param  MockResponse[]  $responses
+     */
+    private function getProvider(array $responses, ?MockHttpClient &$httpClient = null): TrustedPartsProvider
+    {
+        $httpClient = new MockHttpClient($responses);
+
+        $security = $this->createMock(Security::class);
+        $security->method('getUser')->willReturn(null);
+
+        $versionManager = $this->createMock(VersionManagerInterface::class);
+        $versionManager->method('getVersion')->willReturn(Version::fromString('1.2.3'));
+
+        return new TrustedPartsProvider($httpClient, $this->settings, new ArrayAdapter(), $security, $versionManager);
+    }
+
+    private function getSearchResponse(): MockResponse
+    {
+        return new MockResponse(json_encode([
+            'Messages' => [],
+            'ErrorMessage' => null,
+            'PartResults' => [
+                [
+                    'PartNumber' => 'LM358DR',
+                    'Manufacturer' => 'Texas Instruments',
+                    'ManufacturerId' => 1,
+                    'ProductUrl' => 'https://www.trustedparts.com/en/part/texas-instruments/LM358DR',
+                    'Specifications' => [
+                        ['Key' => 'Package / Case', 'Value' => 'SOIC-8'],
+                        ['Key' => 'Subcategory', 'Value' => 'Amplifier ICs'],
+                        ['Key' => 'GBP - Gain Bandwidth Product', 'Value' => '700 kHz'],
+                        //Specifications without a value should be skipped
+                        ['Key' => 'Shutdown', 'Value' => ''],
+                    ],
+                    'Distributors' => [
+                        [
+                            'Id' => 1,
+                            'Name' => 'DigiKey',
+                            'DistributorResults' => [
+                                [
+                                    'Description' => 'Standard Amplifier 2 Circuit 8-SOIC',
+                                    'DistributorPartNumber' => '296-LM358DRCT-ND',
+                                    'Stock' => ['QuantityOnHand' => 1000.0, 'Availability' => 'In Stock'],
+                                    'Links' => [
+                                        ['Type' => 'Buy', 'Url' => 'https://www.trustedparts.com/productredirect?id=buy-digikey'],
+                                        ['Type' => 'Datasheet', 'Url' => 'https://www.trustedparts.com/productredirect?id=datasheet'],
+                                    ],
+                                    'Pricing' => [
+                                        'CurrencyCode' => 'EUR',
+                                        'MinimumQuantity' => 1.0,
+                                        'Prices' => [
+                                            ['Quantity' => 1.0, 'Amount' => 0.22],
+                                            ['Quantity' => 10.0, 'Amount' => 0.15],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'Id' => 2,
+                            'Name' => 'Mouser Electronics',
+                            'DistributorResults' => [
+                                [
+                                    'Description' => 'Operational Amplifiers - Op Amps',
+                                    //Distributors which do not provide an own part number
+                                    'DistributorPartNumber' => 'N/A',
+                                    'Stock' => ['QuantityOnHand' => 0.0, 'Availability' => 'Out of stock'],
+                                    'Links' => [
+                                        ['Type' => 'View', 'Url' => 'https://www.trustedparts.com/productredirect?id=view-mouser'],
+                                        //Empty datasheet links must be skipped
+                                        ['Type' => 'Datasheet', 'Url' => ''],
+                                    ],
+                                    'Pricing' => ['CurrencyCode' => 'USD', 'MinimumQuantity' => 0.0],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR), ['response_headers' => ['content-type' => 'application/json']]);
+    }
+
+    public function testGetProviderInfo(): void
+    {
+        $info = $this->getProvider([])->getProviderInfo();
+
+        $this->assertSame('trustedparts', $info->key);
+        $this->assertSame('TrustedParts', $info->name);
+        $this->assertSame('https://www.trustedparts.com/', $info->url);
+        $this->assertSame(TrustedPartsSettings::class, $info->settingsClass);
+        $this->assertContains(ProviderCapabilities::BASIC, $info->capabilities);
+        $this->assertContains(ProviderCapabilities::PRICE, $info->capabilities);
+        $this->assertContains(ProviderCapabilities::DATASHEET, $info->capabilities);
+        $this->assertContains(ProviderCapabilities::PARAMETERS, $info->capabilities);
+        $this->assertContains(ProviderCapabilities::FOOTPRINT, $info->capabilities);
+    }
+
+    public function testIsActive(): void
+    {
+        $provider = $this->getProvider([]);
+        $this->assertTrue($provider->isActive());
+
+        $this->settings->apiKey = null;
+        $this->assertFalse($provider->isActive());
+
+        $this->settings->apiKey = 'test-api-key';
+        $this->settings->companyId = '';
+        $this->assertFalse($provider->isActive());
+    }
+
+    public function testSearchByKeywordReturnsMappedResults(): void
+    {
+        $provider = $this->getProvider([$this->getSearchResponse()], $httpClient);
+        $results = $provider->searchByKeyword('LM358DR');
+
+        $this->assertCount(1, $results);
+        $result = $results[0];
+        $this->assertInstanceOf(PartDetailDTO::class, $result);
+
+        $this->assertSame('trustedparts', $result->provider_key);
+        $this->assertSame('Texas Instruments|LM358DR', $result->provider_id);
+        $this->assertSame('LM358DR', $result->name);
+        $this->assertSame('LM358DR', $result->mpn);
+        $this->assertSame('Texas Instruments', $result->manufacturer);
+        //The part itself has no description, so the one of the first distributor is used
+        $this->assertSame('Standard Amplifier 2 Circuit 8-SOIC', $result->description);
+        $this->assertSame('Amplifier ICs', $result->category);
+        $this->assertSame('SOIC-8', $result->footprint);
+        $this->assertSame('https://www.trustedparts.com/en/part/texas-instruments/LM358DR', $result->provider_url);
+
+        //Specifications without a value are skipped
+        $this->assertCount(3, $result->parameters);
+
+        //Datasheets without an URL are skipped
+        $this->assertCount(1, $result->datasheets);
+        $this->assertSame('https://www.trustedparts.com/productredirect?id=datasheet', $result->datasheets[0]->url);
+        $this->assertSame('Datasheet (DigiKey)', $result->datasheets[0]->name);
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testSearchByKeywordMapsOffers(): void
+    {
+        $results = $this->getProvider([$this->getSearchResponse()])->searchByKeyword('LM358DR');
+        $orderinfos = $results[0]->vendor_infos;
+
+        $this->assertCount(2, $orderinfos);
+
+        $this->assertSame('DigiKey', $orderinfos[0]->distributor_name);
+        $this->assertSame('296-LM358DRCT-ND', $orderinfos[0]->order_number);
+        $this->assertSame('https://www.trustedparts.com/productredirect?id=buy-digikey', $orderinfos[0]->product_url);
+        $this->assertFalse($orderinfos[0]->prices_include_vat);
+        $this->assertCount(2, $orderinfos[0]->prices);
+        $this->assertSame(1.0, $orderinfos[0]->prices[0]->minimum_discount_amount);
+        $this->assertSame('0.22', $orderinfos[0]->prices[0]->price);
+        $this->assertSame('EUR', $orderinfos[0]->prices[0]->currency_iso_code);
+
+        //If a distributor does not provide an own part number, the MPN is used instead
+        $this->assertSame('Mouser Electronics', $orderinfos[1]->distributor_name);
+        $this->assertSame('LM358DR', $orderinfos[1]->order_number);
+        //Offers without pricing information are still shown
+        $this->assertSame([], $orderinfos[1]->prices);
+    }
+
+    public function testSearchByKeywordRespectsSearchLimit(): void
+    {
+        $this->settings->searchLimit = 1;
+
+        $response = new MockResponse(json_encode([
+            'PartResults' => [
+                ['PartNumber' => 'PART1', 'Manufacturer' => 'Test', 'Specifications' => [], 'Distributors' => []],
+                ['PartNumber' => 'PART2', 'Manufacturer' => 'Test', 'Specifications' => [], 'Distributors' => []],
+            ],
+        ], JSON_THROW_ON_ERROR), ['response_headers' => ['content-type' => 'application/json']]);
+
+        $results = $this->getProvider([$response])->searchByKeyword('PART');
+        $this->assertCount(1, $results);
+    }
+
+    public function testSearchByKeywordWithTooShortKeyword(): void
+    {
+        //The API requires at least two characters, so no request should be made at all
+        $provider = $this->getProvider([], $httpClient);
+        $this->assertSame([], $provider->searchByKeyword('A'));
+        $this->assertSame(0, $httpClient->getRequestsCount());
+    }
+
+    public function testGetDetailsUsesCachedSearchResult(): void
+    {
+        $provider = $this->getProvider([$this->getSearchResponse()], $httpClient);
+        $provider->searchByKeyword('LM358DR');
+
+        //The part was already retrieved during the search, so no additional request must be made
+        $details = $provider->getDetails('Texas Instruments|LM358DR');
+        $this->assertSame('LM358DR', $details->mpn);
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testGetDetailsQueriesApi(): void
+    {
+        $provider = $this->getProvider([$this->getSearchResponse()], $httpClient);
+
+        $details = $provider->getDetails('Texas Instruments|LM358DR');
+        $this->assertSame('Texas Instruments|LM358DR', $details->provider_id);
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testGetDetailsThrowsExceptionForUnknownPart(): void
+    {
+        $response = new MockResponse(json_encode(['PartResults' => []], JSON_THROW_ON_ERROR),
+            ['response_headers' => ['content-type' => 'application/json']]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->getProvider([$response])->getDetails('Texas Instruments|DOES-NOT-EXIST');
+    }
+
+    public function testSearchByKeywordsBatch(): void
+    {
+        $response = new MockResponse(json_encode([
+            'PartResults' => [
+                //The API ignores punctuation, so this is the result for the "BAT54C" query
+                ['PartNumber' => 'BAT-54C', 'Manufacturer' => 'Test', 'Specifications' => [], 'Distributors' => []],
+                ['PartNumber' => 'LM358DR', 'Manufacturer' => 'Test', 'Specifications' => [], 'Distributors' => []],
+            ],
+        ], JSON_THROW_ON_ERROR), ['response_headers' => ['content-type' => 'application/json']]);
+
+        $provider = $this->getProvider([$response], $httpClient);
+        $results = $provider->searchByKeywordsBatch(['BAT54C', 'LM358DR', 'UNKNOWN-PART']);
+
+        //All keywords must be present in the result, even if nothing was found for them
+        $this->assertSame(['BAT54C', 'LM358DR', 'UNKNOWN-PART'], array_keys($results));
+        $this->assertCount(1, $results['BAT54C']);
+        $this->assertSame('BAT-54C', $results['BAT54C'][0]->mpn);
+        $this->assertCount(1, $results['LM358DR']);
+        $this->assertSame([], $results['UNKNOWN-PART']);
+
+        //All keywords must be searched with a single request
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testSearchByKeywordsBatchChunksLargeRequests(): void
+    {
+        //The API refuses requests with more than 50 part numbers, so they have to be split up
+        $keywords = [];
+        for ($i = 1; $i <= 120; $i++) {
+            $keywords[] = 'PART-'.$i;
+        }
+
+        $emptyResponse = static fn() => new MockResponse(json_encode(['PartResults' => []], JSON_THROW_ON_ERROR),
+            ['response_headers' => ['content-type' => 'application/json']]);
+        $responses = [$emptyResponse(), $emptyResponse(), $emptyResponse()];
+
+        $provider = $this->getProvider($responses, $httpClient);
+        $results = $provider->searchByKeywordsBatch($keywords);
+
+        //120 keywords must be split into 3 requests (50 + 50 + 20)
+        $this->assertSame(3, $httpClient->getRequestsCount());
+        $this->assertCount(50, json_decode($responses[0]->getRequestOptions()['body'], true, 512, JSON_THROW_ON_ERROR)['Queries']);
+        $this->assertCount(50, json_decode($responses[1]->getRequestOptions()['body'], true, 512, JSON_THROW_ON_ERROR)['Queries']);
+        $this->assertCount(20, json_decode($responses[2]->getRequestOptions()['body'], true, 512, JSON_THROW_ON_ERROR)['Queries']);
+
+        //Every keyword must be present in the results
+        $this->assertCount(120, $results);
+    }
+
+    public function testSearchByKeywordsBatchSkipsTooShortKeywords(): void
+    {
+        $response = new MockResponse(json_encode(['PartResults' => []], JSON_THROW_ON_ERROR),
+            ['response_headers' => ['content-type' => 'application/json']]);
+
+        $provider = $this->getProvider([$response], $httpClient);
+        $results = $provider->searchByKeywordsBatch(['A', 'LM358DR']);
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+        //The too short keyword must not be sent to the API, but still be present in the results
+        $this->assertSame([['SearchToken' => 'LM358DR']],
+            json_decode($response->getRequestOptions()['body'], true, 512, JSON_THROW_ON_ERROR)['Queries']);
+        $this->assertSame([], $results['A']);
+    }
+
+    public function testApiErrorThrowsException(): void
+    {
+        $response = new MockResponse(json_encode(['ErrorMessage' => 'Invalid API key', 'PartResults' => []],
+            JSON_THROW_ON_ERROR), ['response_headers' => ['content-type' => 'application/json']]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid API key');
+        $this->getProvider([$response])->searchByKeyword('LM358DR');
+    }
+
+    public function testHttpErrorThrowsException(): void
+    {
+        $response = new MockResponse('Unauthorized', ['http_code' => 401]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('TrustedParts API returned HTTP 401');
+        $this->getProvider([$response])->searchByKeyword('LM358DR');
+    }
+
+    public function testRequestContainsCredentialsAndOptions(): void
+    {
+        $this->settings->currency = 'USD';
+        $this->settings->country = 'US';
+        $this->settings->language = 'de';
+        $this->settings->inStockOnly = true;
+
+        $response = $this->getSearchResponse();
+        $this->getProvider([$response])->searchByKeyword('LM358DR');
+
+        $body = $response->getRequestOptions()['body'];
+        $this->assertIsString($body);
+        $request = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('Test Company', $request['CompanyId']);
+        $this->assertSame('test-api-key', $request['ApiKey']);
+        $this->assertSame([['SearchToken' => 'LM358DR']], $request['Queries']);
+        $this->assertSame('USD', $request['CurrencyCode']);
+        $this->assertSame('US', $request['CountryCode']);
+        $this->assertSame('de', $request['LanguageCode']);
+        $this->assertTrue($request['InStockOnly']);
+        //A single keyword search must allow partial matches
+        $this->assertFalse($request['ExactMatch']);
+        $this->assertFalse($request['IsCrawler']);
+        //The terms of use require to identify the application and the user
+        $this->assertSame('Part-DB/1.2.3 (system)', $request['UserAgent']);
+    }
+}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -13898,6 +13898,72 @@ Buerklin-API Authentication server:
         <target>When selected, more details will be fetched from canopy when creating a part. This causes an additional API request, but gives product bullet points and category info.</target>
       </segment>
     </unit>
+    <unit id="KyC_YsX" name="settings.ips.trustedparts">
+      <segment state="translated">
+        <source>settings.ips.trustedparts</source>
+        <target>TrustedParts</target>
+      </segment>
+    </unit>
+    <unit id="iB2.9sg" name="settings.ips.trustedparts.help">
+      <segment state="translated">
+        <source>settings.ips.trustedparts.help</source>
+        <target>TrustedParts.com is a part search engine operated by the ECIA, which aggregates the offers of authorized distributors. You have to request access to their API to use this provider.</target>
+      </segment>
+    </unit>
+    <unit id="Mhe.lWu" name="settings.ips.trustedparts.companyId">
+      <segment state="translated">
+        <source>settings.ips.trustedparts.companyId</source>
+        <target>Company ID</target>
+      </segment>
+    </unit>
+    <unit id="DvzhYe1" name="settings.ips.trustedparts.companyId.help">
+      <segment state="translated">
+        <source>settings.ips.trustedparts.companyId.help</source>
+        <target>The company identifier which was assigned to your TrustedParts.com account. You can find it on the API key page of your account.</target>
+      </segment>
+    </unit>
+    <unit id="AqF7ns9" name="settings.ips.trustedparts.apiKey.help">
+      <segment state="translated">
+        <source>settings.ips.trustedparts.apiKey.help</source>
+        <target>The API key which was assigned to your TrustedParts.com account. You can find it on the API key page of your account.</target>
+      </segment>
+    </unit>
+    <unit id="Gh676P6" name="settings.ips.trustedparts.searchLimit">
+      <segment state="translated">
+        <source>settings.ips.trustedparts.searchLimit</source>
+        <target>Search limit</target>
+      </segment>
+    </unit>
+    <unit id="R7oiMLD" name="settings.ips.trustedparts.searchLimit.help">
+      <segment state="translated">
+        <source>settings.ips.trustedparts.searchLimit.help</source>
+        <target>The maximum number of results which are shown for a keyword search.</target>
+      </segment>
+    </unit>
+    <unit id="DFkCu4n" name="settings.ips.trustedparts.inStockOnly">
+      <segment state="translated">
+        <source>settings.ips.trustedparts.inStockOnly</source>
+        <target>Only offers in stock</target>
+      </segment>
+    </unit>
+    <unit id="EF2mFRR" name="settings.ips.trustedparts.inStockOnly.help">
+      <segment state="translated">
+        <source>settings.ips.trustedparts.inStockOnly.help</source>
+        <target>If enabled, only the offers of distributors which currently have the part in stock are returned.</target>
+      </segment>
+    </unit>
+    <unit id="r4gkOcR" name="settings.ips.trustedparts.useCachedData">
+      <segment state="translated">
+        <source>settings.ips.trustedparts.useCachedData</source>
+        <target>Use cached data</target>
+      </segment>
+    </unit>
+    <unit id="JNIu4bu" name="settings.ips.trustedparts.useCachedData.help">
+      <segment state="translated">
+        <source>settings.ips.trustedparts.useCachedData.help</source>
+        <target>If enabled, TrustedParts.com answers with cached stock and price data instead of querying the distributors in real time. This is faster and does not count against the rate limits, but the data can be outdated.</target>
+      </segment>
+    </unit>
     <unit id="D055xh8" name="attachment.sandbox.warning">
       <segment state="translated">
         <source>attachment.sandbox.warning</source>


### PR DESCRIPTION
TrustedParts.com is a part search engine operated by the Electronic Components Industry Association, which aggregates stock, prices and specifications of authorized distributors. Its Inventory API is free to use, but requires an approved account (company ID + API key).

The API has no part IDs, parts are always identified by their part number, so the provider IDs are built as "manufacturer|mpn". A single search already returns all offers and specifications, therefore the results are cached and reused for the detail view.

As the API can search up to 50 part numbers in a single request, the provider also implements BatchInfoProviderInterface for the bulk import.

Requests are sent with a user agent identifying Part-DB and the current user ID, as required by the API terms of use for non-website applications.

The datasheet links of this provider are redirect URLs without a file extension, which uncovered a separate problem in `Attachment::isPicture()` (broken preview images). That is fixed in #1520, independently of this PR.