### PR TITLE
Fix broken preview images for extension-less external files

### DIFF
--- a/src/Entity/Attachments/Attachment.php
+++ b/src/Entity/Attachments/Attachment.php
@@ -289,10 +289,43 @@ abstract class Attachment extends AbstractNamedDBElement
             //Check if we can extract a file extension from the URL
             $extension = pathinfo(parse_url($this->getExternalPath(), PHP_URL_PATH) ?? '', PATHINFO_EXTENSION);
 
-            //If no extension is found or it is known picture extension, we assume that this is a picture extension
-            return $extension === '' || in_array(strtolower($extension), static::PICTURE_EXTS, true);
+            if (in_array(strtolower($extension), static::PICTURE_EXTS, true)) {
+                return true;
+            }
+
+            //If no extension is found (e.g. for URLs which redirect to the actual file), we can only guess. We assume
+            //that it is a picture, unless the attachment type rules pictures out (like the "Datasheet" type, which only
+            //allows PDFs), as we would show a broken image otherwise.
+            return $extension === '' && $this->attachmentTypeAllowsPictures();
         }
         //File doesn't have an internal, nor an external copy. This shouldn't happen, but it certainly isn't a picture...
+        return false;
+    }
+
+    /**
+     * Checks whether the filetype filter of the attachment type allows pictures.
+     * If no attachment type is set, or it does not restrict the filetypes, true is returned, as we can not tell.
+     */
+    private function attachmentTypeAllowsPictures(): bool
+    {
+        $filter = trim($this->getAttachmentType()?->getFiletypeFilter() ?? '');
+
+        if ($filter === '') {
+            return true;
+        }
+
+        foreach (explode(',', $filter) as $allowed) {
+            $allowed = trim(strtolower($allowed));
+
+            if ($allowed === '*' || $allowed === '*/*' || str_starts_with($allowed, 'image/')) {
+                return true;
+            }
+
+            if (in_array(ltrim($allowed, '.'), static::PICTURE_EXTS, true)) {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/src/Entity/Attachments/Attachment.php
+++ b/src/Entity/Attachments/Attachment.php
@@ -285,6 +285,7 @@ abstract class Attachment extends AbstractNamedDBElement
             return in_array(strtolower($extension), static::PICTURE_EXTS, true);
 
         }
+
         if ($this->hasExternal()) {
             //Check if we can extract a file extension from the URL
             $extension = pathinfo(parse_url($this->getExternalPath(), PHP_URL_PATH) ?? '', PATHINFO_EXTENSION);
@@ -296,36 +297,10 @@ abstract class Attachment extends AbstractNamedDBElement
             //If no extension is found (e.g. for URLs which redirect to the actual file), we can only guess. We assume
             //that it is a picture, unless the attachment type rules pictures out (like the "Datasheet" type, which only
             //allows PDFs), as we would show a broken image otherwise.
-            return $extension === '' && $this->attachmentTypeAllowsPictures();
+            return $extension === '' && ($this->getAttachmentType()?->allowsPictures() ?? true);
         }
+
         //File doesn't have an internal, nor an external copy. This shouldn't happen, but it certainly isn't a picture...
-        return false;
-    }
-
-    /**
-     * Checks whether the filetype filter of the attachment type allows pictures.
-     * If no attachment type is set, or it does not restrict the filetypes, true is returned, as we can not tell.
-     */
-    private function attachmentTypeAllowsPictures(): bool
-    {
-        $filter = trim($this->getAttachmentType()?->getFiletypeFilter() ?? '');
-
-        if ($filter === '') {
-            return true;
-        }
-
-        foreach (explode(',', $filter) as $allowed) {
-            $allowed = trim(strtolower($allowed));
-
-            if ($allowed === '*' || $allowed === '*/*' || str_starts_with($allowed, 'image/')) {
-                return true;
-            }
-
-            if (in_array(ltrim($allowed, '.'), static::PICTURE_EXTS, true)) {
-                return true;
-            }
-        }
-
         return false;
     }
 

--- a/src/Entity/Attachments/AttachmentType.php
+++ b/src/Entity/Attachments/AttachmentType.php
@@ -192,6 +192,32 @@ class AttachmentType extends AbstractStructuralDBElement
     }
 
     /**
+     * Checks if this attachment type allows pictures (i.e. if the filetype filter allows image files).
+     * If no filetype filter is set, this method returns true, as it is assumed that all file types are allowed.
+     * @return bool
+     */
+    public function allowsPictures(): bool
+    {
+        if ($this->filetype_filter === '') {
+            return true;
+        }
+
+        foreach (explode(',', $this->filetype_filter) as $allowed) {
+            $allowed = strtolower(trim($allowed));
+
+            if ($allowed === '*' || $allowed === '*/*' || str_starts_with($allowed, 'image/')) {
+                return true;
+            }
+
+            if (in_array(ltrim($allowed, '.'), Attachment::PICTURE_EXTS, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Returns a list of allowed targets as class names (e.g. PartAttachment::class), where this attachment type can be assigned to. If null, there are no restrictions.
      * @return class-string<Attachment>[]|null
      */

--- a/tests/Entity/Attachments/AttachmentTest.php
+++ b/tests/Entity/Attachments/AttachmentTest.php
@@ -171,6 +171,31 @@ final class AttachmentTest extends TestCase
         $this->assertSame($expected, $attachment->isPicture());
     }
 
+    public static function pictureFiletypeFilterDataProvider(): \Iterator
+    {
+        //An URL without a file extension is only assumed to be a picture, if the attachment type allows pictures
+        yield ['https://invalid.com/redirect?id=1234', '',                  true];
+        yield ['https://invalid.com/redirect?id=1234', 'image/*',           true];
+        yield ['https://invalid.com/redirect?id=1234', '.jpg,.png',         true];
+        yield ['https://invalid.com/redirect?id=1234', 'application/pdf',   false];
+        yield ['https://invalid.com/redirect?id=1234', '.pdf,.txt',         false];
+        //An URL with a picture extension is always a picture, no matter what the attachment type says
+        yield ['https://invalid.com/picture.jpeg',     'application/pdf',   true];
+    }
+
+    #[DataProvider('pictureFiletypeFilterDataProvider')]
+    public function testIsPictureRespectsFiletypeFilter(string $external_path, string $filter, bool $expected): void
+    {
+        $attachment_type = new AttachmentType();
+        $attachment_type->setFiletypeFilter($filter);
+
+        $attachment = new PartAttachment();
+        $attachment->setAttachmentType($attachment_type);
+        $this->setProtectedProperty($attachment, 'external_path', $external_path);
+
+        $this->assertSame($expected, $attachment->isPicture());
+    }
+
     public static function builtinDataProvider(): \Iterator
     {
         yield ['', false];

--- a/tests/Entity/Attachments/AttachmentTypeTest.php
+++ b/tests/Entity/Attachments/AttachmentTypeTest.php
@@ -26,6 +26,7 @@ use App\Entity\Attachments\AttachmentType;
 use App\Entity\Attachments\PartAttachment;
 use App\Entity\Attachments\UserAttachment;
 use Doctrine\Common\Collections\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class AttachmentTypeTest extends TestCase
@@ -82,5 +83,34 @@ final class AttachmentTypeTest extends TestCase
         $attachmentType->setAllowedTargets(null);
         $this->assertTrue($attachmentType->isAllowedForTarget(PartAttachment::class));
         $this->assertTrue($attachmentType->isAllowedForTarget(UserAttachment::class));
+    }
+
+    public static function allowsPictureDataProvider(): array
+    {
+        return [
+            ['', true],
+            ['image/*', true],
+            ['image/png,image/jpeg', true],
+            ['application/pdf', false],
+            ['text/plain', false],
+            ['image/gif,application/pdf', true],
+            ['audio/mpeg', false],
+            ['video/mp4', false],
+            ['image/svg+xml', true],
+            ['application/zip', false],
+            ['image/webp,text/html', true],
+            ['*', true],
+            ['.pdf,.png', true],
+            ['.jpeg,.gif', true],
+            ['.pdf,.xml', false],
+        ];
+    }
+
+    #[DataProvider('allowsPictureDataProvider')]
+    public function testAllowsPicture(string $filetype_filter, bool $expected): void
+    {
+        $attachmentType = new AttachmentType();
+        $attachmentType->setFiletypeFilter($filetype_filter);
+        $this->assertSame($expected, $attachmentType->allowsPictures());
     }
 }


### PR DESCRIPTION
If no file extension can be extracted from the URL of an external attachment, Part-DB assumed that it is a picture. That is a sensible guess for image URLs, but it also applies to URLs which redirect to the actual file, like the datasheet links of the TrustedParts provider (https://www.trustedparts.com/productredirect?id=...).

Such datasheets were rendered as an <img> in the attachment lists (showing a broken image) and the first one was automatically used as the preview picture of the part by the AttachmentSubmitHandler, so the part page showed a broken main image too.

The attachment type already knows which filetypes it may contain (the "Datasheet" type created by the info provider system is restricted to application/pdf), so use that information for the guess. Attachments whose URL has a known picture extension are unaffected, as are attachment types without a filetype filter.

Existing parts heal themselves: the AttachmentSubmitHandler already removes a master picture attachment which is not a picture anymore, as soon as the part is saved the next time.