### PR TITLE
Version the cache keys of the info provider DTOs

### DIFF
--- a/src/Services/InfoProviderSystem/PartInfoRetriever.php
+++ b/src/Services/InfoProviderSystem/PartInfoRetriever.php
@@ -41,6 +41,14 @@ final class PartInfoRetriever
     private const CACHE_DETAIL_EXPIRATION = 60 * 60 * 24 * 4; // 4 days
     private const CACHE_RESULT_EXPIRATION = 60 * 60 * 24 * 4; // 7 days
 
+    /**
+     * @var string The info provider DTOs are cached as serialized objects, and that cache outlives an update of
+     * Part-DB (it is not stored in the cache directory). Restoring an object of an older version into a class with
+     * new properties fails, as those properties stay uninitialized, so this marker is part of every cache key of a
+     * DTO and has to be increased whenever the structure of the DTOs changes.
+     */
+    public const DTO_CACHE_VERSION = 'v2';
+
     public function __construct(private readonly ProviderRegistry $provider_registry,
         private readonly DTOtoEntityConverter $dto_to_entity_converter, private readonly CacheInterface $partInfoCache,
         #[Autowire(param: "kernel.debug")]
@@ -102,7 +110,7 @@ final class PartInfoRetriever
         //Generate a hash for the options, to ensure that different options result in different cache entries
         $options_hash = hash('xxh3', json_encode($options_without_cache, JSON_THROW_ON_ERROR));
 
-        $cache_key = "search_{$provider->getProviderInfo()->key}_{$escaped_keyword}_{$options_hash}";
+        $cache_key = "search_".self::DTO_CACHE_VERSION."_{$provider->getProviderInfo()->key}_{$escaped_keyword}_{$options_hash}";
 
         //If no_cache is set, bypass the cache and get fresh results from the provider
         if ($no_cache) {
@@ -144,7 +152,7 @@ final class PartInfoRetriever
 
         //Generate key and escape reserved characters from the provider id
         $escaped_part_id = hash('xxh3', $part_id);
-        $cache_key = "details_{$provider_key}_{$escaped_part_id}_{$options_hash}";
+        $cache_key = "details_".self::DTO_CACHE_VERSION."_{$provider_key}_{$escaped_part_id}_{$options_hash}";
 
         //Delete the cache entry if no_cache is set, to ensure that the next get call will fetch fresh data from the provider, instead of returning stale data from the cache.
         if ($options[InfoProviderInterface::OPTION_NO_CACHE] ?? false) {

--- a/src/Services/InfoProviderSystem/Providers/CanopyProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/CanopyProvider.php
@@ -27,6 +27,7 @@ use App\Services\InfoProviderSystem\DTOs\PartDetailDTO;
 use App\Services\InfoProviderSystem\DTOs\PriceDTO;
 use App\Services\InfoProviderSystem\DTOs\ProviderInfoDTO;
 use App\Services\InfoProviderSystem\DTOs\PurchaseInfoDTO;
+use App\Services\InfoProviderSystem\PartInfoRetriever;
 use App\Settings\InfoProviderSystem\CanopySettings;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -86,7 +87,7 @@ class CanopyProvider implements InfoProviderInterface
      */
     private function saveToCache(PartDetailDTO $part): void
     {
-        $key = 'canopy_part_'.$part->provider_id;
+        $key = 'canopy_part_'.PartInfoRetriever::DTO_CACHE_VERSION.'_'.$part->provider_id;
 
         $item = $this->partInfoCache->getItem($key);
         $item->set($part);
@@ -101,7 +102,7 @@ class CanopyProvider implements InfoProviderInterface
      */
     private function getFromCache(string $id): ?PartDetailDTO
     {
-        $key = 'canopy_part_'.$id;
+        $key = 'canopy_part_'.PartInfoRetriever::DTO_CACHE_VERSION.'_'.$id;
 
         $item = $this->partInfoCache->getItem($key);
         if ($item->isHit()) {

--- a/src/Services/InfoProviderSystem/Providers/OctopartProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/OctopartProvider.php
@@ -30,6 +30,7 @@ use App\Services\InfoProviderSystem\DTOs\PartDetailDTO;
 use App\Services\InfoProviderSystem\DTOs\PriceDTO;
 use App\Services\InfoProviderSystem\DTOs\ProviderInfoDTO;
 use App\Services\InfoProviderSystem\DTOs\PurchaseInfoDTO;
+use App\Services\InfoProviderSystem\PartInfoRetriever;
 use App\Services\OAuth\OAuthTokenManager;
 use App\Settings\InfoProviderSystem\OctopartSettings;
 use Psr\Cache\CacheItemPoolInterface;
@@ -215,7 +216,7 @@ class OctopartProvider implements InfoProviderInterface
      */
     private function saveToCache(PartDetailDTO $part): void
     {
-        $key = 'octopart_part_'.$part->provider_id;
+        $key = 'octopart_part_'.PartInfoRetriever::DTO_CACHE_VERSION.'_'.$part->provider_id;
 
         $item = $this->partInfoCache->getItem($key);
         $item->set($part);
@@ -230,7 +231,7 @@ class OctopartProvider implements InfoProviderInterface
      */
     private function getFromCache(string $id): ?PartDetailDTO
     {
-        $key = 'octopart_part_'.$id;
+        $key = 'octopart_part_'.PartInfoRetriever::DTO_CACHE_VERSION.'_'.$id;
 
         $item = $this->partInfoCache->getItem($key);
         if ($item->isHit()) {

--- a/src/Services/InfoProviderSystem/Providers/TrustedPartsProvider.php
+++ b/src/Services/InfoProviderSystem/Providers/TrustedPartsProvider.php
@@ -30,6 +30,7 @@ use App\Services\InfoProviderSystem\DTOs\PartDetailDTO;
 use App\Services\InfoProviderSystem\DTOs\PriceDTO;
 use App\Services\InfoProviderSystem\DTOs\ProviderInfoDTO;
 use App\Services\InfoProviderSystem\DTOs\PurchaseInfoDTO;
+use App\Services\InfoProviderSystem\PartInfoRetriever;
 use App\Settings\InfoProviderSystem\TrustedPartsSettings;
 use Psr\Cache\CacheItemPoolInterface;
 use Shivas\VersioningBundle\Service\VersionManagerInterface;
@@ -436,6 +437,6 @@ class TrustedPartsProvider implements BatchInfoProviderInterface
     private function cacheKey(string $id): string
     {
         //The IDs contain characters which are not allowed in cache keys, so we hash them
-        return 'trustedparts_part_'.hash('xxh3', $id);
+        return 'trustedparts_part_'.PartInfoRetriever::DTO_CACHE_VERSION.'_'.hash('xxh3', $id);
     }
 }


### PR DESCRIPTION
The info provider system caches the DTOs it received from a provider as serialized objects, in a cache pool which is not part of the cache directory and therefore survives an update of Part-DB.

Whenever a DTO class gains a property, unserializing an object which was cached by an older version leaves that property uninitialized, so the first access to it fails with a typed property error until the cache happens to expire (up to four days later).

Add a version marker to every cache key of a DTO, which has to be increased whenever the structure of the DTOs changes: old entries are then simply never read again and expire on their own.