### PR TITLE
Fix stale KiCad category listing after EDA settings change

### DIFF
--- a/src/Services/EDA/KiCadHelper.php
+++ b/src/Services/EDA/KiCadHelper.php
@@ -145,7 +145,10 @@ final readonly class KiCadHelper
      */
     public function getCategoryParts(?Category $category): array
     {
-        $cacheKey = 'kicad_category_parts_'.($category?->getID() ?? 0) . '_' . $this->category_depth;
+        // Settings fingerprint keeps cached responses from surviving settings changes
+        // (tag-based invalidation only fires on part/category/footprint edits)
+        $cacheKey = 'kicad_category_parts_'.($category?->getID() ?? 0) . '_' . $this->category_depth
+            . '_' . $this->edaSettingsFingerprint();
         return $this->kicadCache->get($cacheKey,
             function (ItemInterface $item) use ($category) {
                 $item->tag([
@@ -353,6 +356,19 @@ final readonly class KiCadHelper
         }
 
         return $result;
+    }
+
+    /**
+     * Fingerprint of every setting that changes the content of a serialized part.
+     */
+    private function edaSettingsFingerprint(): string
+    {
+        return md5(json_encode([
+            $this->datasheetAsPdf,
+            $this->kiCadEDASettings->defaultOrderdetailsVisibility,
+            $this->kiCadEDASettings->defaultParameterVisibility,
+            $this->kiCadEDASettings->defaultParameterSymbolVisibility,
+        ], JSON_THROW_ON_ERROR));
     }
 
     /**

--- a/tests/Services/EDA/KiCadHelperTest.php
+++ b/tests/Services/EDA/KiCadHelperTest.php
@@ -33,6 +33,7 @@ use App\Entity\Parts\StorageLocation;
 use App\Entity\Parts\Supplier;
 use App\Entity\PriceInformations\Orderdetail;
 use App\Services\EDA\KiCadHelper;
+use App\Settings\MiscSettings\KiCadEDASettings;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -653,5 +654,39 @@ final class KiCadHelperTest extends KernelTestCase
             self::assertArrayHasKey('footprint', $part['fields']);
             self::assertArrayHasKey('symbolIdStr', $part);
         }
+    }
+
+    /**
+     * The category listing is cached and only invalidated by entity changes.
+     * Changing a setting that affects the exported fields must not serve a stale listing.
+     */
+    public function testCategoryPartsCacheIsInvalidatedBySettingsChange(): void
+    {
+        /** @var KiCadEDASettings $settings */
+        $settings = self::getContainer()->get(KiCadEDASettings::class);
+        $category = $this->em->find(Category::class, 1);
+
+        $part = new Part();
+        $part->setName('Part for cache test');
+        $part->setCategory($category);
+        $param = new PartParameter();
+        $param->setName('CacheTestParam');
+        $param->setValueText('42');
+        $param->setEdaVisibility(null);
+        $part->addParameter($param);
+        $this->em->persist($part);
+        $this->em->flush();
+
+        $findFields = fn(array $listing): array => array_values(array_filter($listing, fn($p) => (int) $p['id'] === $part->getId()))[0]['fields'];
+
+        $settings->defaultParameterVisibility = false;
+        $before = $findFields($this->helper->getCategoryParts($category));
+        self::assertArrayNotHasKey('CacheTestParam', $before);
+
+        // No entity changed, only the setting: the cached listing must not be reused
+        $settings->defaultParameterVisibility = true;
+        $after = $findFields($this->helper->getCategoryParts($category));
+        self::assertArrayHasKey('CacheTestParam', $after);
+        self::assertSame('42', $after['CacheTestParam']['value']);
     }
 }


### PR DESCRIPTION
> [!NOTE]
> 🤖 Claude Fable 5.1 opening this PR on behalf of @lukas-runge

## Problem

The KiCad category parts listing (`/kicad-api/v1/parts/category/{id}.json`) is cached in `KiCadHelper::getCategoryParts()`. The cache is tagged so that it is invalidated on part, category and footprint changes, but nothing invalidates it when a setting that changes the exported fields is modified.

To reproduce:

1. Let KiCad load a category, so the listing is cached.
2. In the server settings under "KiCAD integration" toggle "Datasheet field links to PDF" or one of the default visibility options for parameters/orderdetails.
3. Request the listing again. It still contains the old fields until some part in the database is edited.

There is no existing issue for this, I found it while working on #1533.

## Fix

Include a fingerprint of the settings that affect the serialized part (`datasheetAsPdf`, `defaultOrderdetailsVisibility`, `defaultParameterVisibility`, `defaultParameterSymbolVisibility`) in the cache key. A settings change then results in a new key and a fresh listing. Stale entries expire with the pool as before.

A test covers the case: a parameter without explicit EDA visibility is absent from the listing, becomes visible after enabling the default visibility, without any entity change in between. The test fails without the fix.

#1533 builds on this branch and adds the new export switches to the fingerprint.
