### PR TITLE
Pace the requests Part-DB sends to the info providers

### DIFF
--- a/docs/usage/information_provider_system.md
+++ b/docs/usage/information_provider_system.md
@@ -388,3 +388,31 @@ To reduce the number of API calls against the providers, the results are cached:
 If you need a fresh result, you can clear the cache by running `php .\bin\console cache:pool:clear info_provider.cache`
 on the command line.
 The default `php bin/console cache:clear` also clears the result cache, as it clears all caches.
+
+## Rate limiting
+
+Info providers enforce rate limits per account, usually in short windows (TrustedParts, for example, allows 50
+requests per 10 seconds and 150 per minute), and many of them bill per request. Part-DB can easily produce
+bursts above that: a bulk import or an update of many parts walks through them as fast as the network allows.
+
+Part-DB therefore paces its own requests to each provider. The limits are configured under
+*System settings → Info providers → General*:
+
+* **Max. provider requests per 10 seconds** (default 35)
+* **Max. provider requests per minute** (default 120)
+* **Max. wait for a free slot** (default 30 seconds)
+
+Requests are delayed, not rejected - a bulk operation simply takes a little longer. Only if a single request
+would have to wait longer than the configured maximum does it fail, so that a request started from the user
+interface cannot hang indefinitely. Such a failure answers with HTTP 429 and a `Retry-After` header naming the
+seconds until the next free slot, so an automated caller can tell "too fast, come back shortly" apart from a
+real error. Setting a limit to 0 disables that window.
+
+Each provider is counted separately, since the limits belong to a provider account, and cached responses are not
+counted at all - only requests which really reach the provider.
+
+The defaults deliberately stay below what providers allow. The reason is that the provider counts *your account*,
+not Part-DB: if an external script uses the same API credentials (for example a job which maintains parts
+through the API), its requests and Part-DB's add up, and neither side can see the other's count. The remaining
+headroom is what keeps the two from pushing each other over the limit. If you know that nothing else uses the
+account, you can raise the values.

--- a/src/Exceptions/InfoProviderRateLimitExceededException.php
+++ b/src/Exceptions/InfoProviderRateLimitExceededException.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * This file is part of Part-DB (https://github.com/Part-DB/Part-DB-symfony).
+ *
+ *  Copyright (C) 2019 - 2026 Jan Böhmer (https://github.com/jbtronics)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+
+/**
+ * Thrown when an info provider request had to be delayed by the rate limit for longer than the configured
+ * maximum wait time, so that a caller gets a clear error instead of a request which seems to hang forever.
+ *
+ * This is an HTTP exception on purpose: hitting the rate limit is an expected, temporary condition, and every
+ * entry point - the web interface, the REST API and the MCP tools alike - should answer it with 429 and a
+ * Retry-After header rather than a 500, so that an automated caller can tell "too fast, try again shortly"
+ * apart from "something is broken".
+ */
+class InfoProviderRateLimitExceededException extends TooManyRequestsHttpException
+{
+    /**
+     * @param  int  $waitedSeconds How long this request was already delayed before giving up
+     * @param  int  $retryAfter    How many seconds to wait before the next slot is free
+     */
+    public function __construct(
+        public readonly string $providerKey,
+        public readonly int $waitedSeconds,
+        public readonly int $retryAfter,
+    ) {
+        parent::__construct($this->retryAfter, sprintf(
+            'The rate limit for the info provider "%s" would delay this request by more than %d seconds. '
+            .'Retry in %d seconds, or raise the info provider rate limit in the system settings.',
+            $this->providerKey, $this->waitedSeconds, $this->retryAfter
+        ));
+    }
+}

--- a/src/Services/InfoProviderSystem/InfoProviderRateLimiter.php
+++ b/src/Services/InfoProviderSystem/InfoProviderRateLimiter.php
@@ -1,0 +1,159 @@
+<?php
+/*
+ * This file is part of Part-DB (https://github.com/Part-DB/Part-DB-symfony).
+ *
+ *  Copyright (C) 2019 - 2026 Jan Böhmer (https://github.com/jbtronics)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace App\Services\InfoProviderSystem;
+
+use App\Exceptions\InfoProviderRateLimitExceededException;
+use App\Settings\InfoProviderSystem\InfoProviderGeneralSettings;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\RateLimiter\CompoundLimiter;
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\CacheStorage;
+
+/**
+ * Paces the requests Part-DB sends to a single info provider.
+ *
+ * Providers enforce short-window rate limits (TrustedParts, for example, allows 50 requests per 10 seconds and
+ * 150 per minute) and often bill per request, while Part-DB can produce bursts far above that: a bulk import or
+ * a bulk refresh walks through hundreds of parts as fast as the network allows. Worse, the limit is per account,
+ * so an external script using the same API credentials shares the budget - and neither side can see the other's
+ * request count.
+ *
+ * This limiter is therefore the one place all provider traffic is paced, and it stores its counters in the
+ * shared cache pool rather than in memory, so every web request, console command and background job counts
+ * against the same budget. Each provider gets its own counters, since the limits are per provider account.
+ *
+ * Requests are delayed, not rejected: the caller waits until the next slot is free, which is what a bulk
+ * operation wants. Only when the wait would exceed the configured maximum does it throw, so an interactive
+ * request cannot hang indefinitely.
+ *
+ * Two things this deliberately does not do. It does not count cached provider responses - it is called from
+ * PartInfoRetriever inside the cache callbacks, so only requests which really reach the provider are counted.
+ * And it does not synchronize its counter updates with a lock, which means parallel processes can slightly
+ * under-count; the configured limit should therefore stay below the provider's real one (the defaults do).
+ */
+final class InfoProviderRateLimiter
+{
+    /**
+     * @var LimiterInterface[] Limiters per provider key, built lazily
+     */
+    private array $limiters = [];
+
+    /**
+     * @var float How long to sleep at most in one go, so a changed limit or a freed slot is noticed reasonably fast
+     */
+    private const MAX_SLEEP_STEP = 1.0;
+
+    public function __construct(
+        private readonly CacheItemPoolInterface $cache,
+        private readonly InfoProviderGeneralSettings $settings,
+    ) {
+    }
+
+    /**
+     * Waits until the given provider may be queried again, and counts this request against its budget.
+     *
+     * @throws InfoProviderRateLimitExceededException if the wait would exceed the configured maximum
+     */
+    public function await(string $provider_key): void
+    {
+        $limiter = $this->limiterFor($provider_key);
+
+        //No limits configured at all - nothing to pace
+        if ($limiter === null) {
+            return;
+        }
+
+        $max_wait = max(0, $this->settings->rateLimitMaxWait);
+        $waited = 0.0;
+
+        while (true) {
+            $limit = $limiter->consume();
+
+            if ($limit->isAccepted()) {
+                return;
+            }
+
+            if ($waited >= $max_wait) {
+                //Tell the caller when it is worth trying again, instead of leaving it to guess
+                $retry_after = max(1, $limit->getRetryAfter()->getTimestamp() - time());
+
+                throw new InfoProviderRateLimitExceededException($provider_key, $max_wait, $retry_after);
+            }
+
+            $sleep = min(self::MAX_SLEEP_STEP, $max_wait - $waited);
+            usleep((int) ($sleep * 1_000_000));
+            $waited += $sleep;
+        }
+    }
+
+    /**
+     * Builds the limiter for a provider, or returns null if no limit is configured.
+     */
+    private function limiterFor(string $provider_key): ?LimiterInterface
+    {
+        if (array_key_exists($provider_key, $this->limiters)) {
+            return $this->limiters[$provider_key];
+        }
+
+        $storage = new CacheStorage($this->cache);
+        $limiters = [];
+
+        foreach ($this->windows() as $name => [$limit, $interval]) {
+            $factory = new RateLimiterFactory([
+                'id' => 'info_provider_'.$name,
+                'policy' => 'sliding_window',
+                'limit' => $limit,
+                'interval' => $interval,
+            ], $storage);
+
+            $limiters[] = $factory->create($provider_key);
+        }
+
+        return $this->limiters[$provider_key] = match (count($limiters)) {
+            0 => null,
+            1 => $limiters[0],
+            default => new CompoundLimiter($limiters),
+        };
+    }
+
+    /**
+     * @return array<string, array{int, string}> The configured windows as limit and interval, keyed by a name
+     *                                           which is part of the counter's cache key
+     */
+    private function windows(): array
+    {
+        $windows = [];
+
+        //A limit of 0 disables that window
+        if ($this->settings->rateLimitPer10Seconds > 0) {
+            $windows['10s'] = [$this->settings->rateLimitPer10Seconds, '10 seconds'];
+        }
+
+        if ($this->settings->rateLimitPerMinute > 0) {
+            $windows['1m'] = [$this->settings->rateLimitPerMinute, '1 minute'];
+        }
+
+        return $windows;
+    }
+}

--- a/src/Services/InfoProviderSystem/PartInfoRetriever.php
+++ b/src/Services/InfoProviderSystem/PartInfoRetriever.php
@@ -43,6 +43,7 @@ final class PartInfoRetriever
 
     public function __construct(private readonly ProviderRegistry $provider_registry,
         private readonly DTOtoEntityConverter $dto_to_entity_converter, private readonly CacheInterface $partInfoCache,
+        private readonly InfoProviderRateLimiter $rateLimiter,
         #[Autowire(param: "kernel.debug")]
         private readonly bool $debugMode = false)
     {
@@ -113,6 +114,9 @@ final class PartInfoRetriever
             //Set the expiration time
             $item->expiresAfter(!$this->debugMode ? self::CACHE_RESULT_EXPIRATION : 10);
 
+            //Only requests which really reach the provider are paced - a cache hit never gets here
+            $this->rateLimiter->await($provider->getProviderInfo()->key);
+
             return $provider->searchByKeyword($keyword, $options);
         });
     }
@@ -154,6 +158,9 @@ final class PartInfoRetriever
         return $this->partInfoCache->get($cache_key, function (ItemInterface $item) use ($provider, $part_id, $options) {
             //Set the expiration time
             $item->expiresAfter(!$this->debugMode ? self::CACHE_DETAIL_EXPIRATION : 10);
+
+            //Only requests which really reach the provider are paced - a cache hit never gets here
+            $this->rateLimiter->await($provider->getProviderInfo()->key);
 
             return $provider->getDetails($part_id, $options);
         });

--- a/src/Settings/InfoProviderSystem/InfoProviderGeneralSettings.php
+++ b/src/Settings/InfoProviderSystem/InfoProviderGeneralSettings.php
@@ -30,6 +30,7 @@ use Jbtronics\SettingsBundle\ParameterTypes\StringType;
 use Jbtronics\SettingsBundle\Settings\Settings;
 use Jbtronics\SettingsBundle\Settings\SettingsParameter;
 use Symfony\Component\Translation\TranslatableMessage as TM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[Settings(label: new TM("settings.ips.general"))]
 #[SettingsIcon("fa-magnifying-glass")]
@@ -42,4 +43,31 @@ class InfoProviderGeneralSettings
         description: new TM("settings.ips.default_providers.help"), options: ['type' => StringType::class],
         formType: ProviderSelectType::class, formOptions: ['input' => 'string', 'required' => false, 'empty_data' => []])]
     public array $defaultSearchProviders = [];
+
+    /**
+     * @var int The maximum number of requests Part-DB sends to a single provider within 10 seconds, or 0 for no
+     * limit. The default leaves headroom below the shortest window the providers typically enforce, so that an
+     * external script sharing the same API account does not push the total over the provider's limit.
+     */
+    #[SettingsParameter(label: new TM("settings.ips.rate_limit_per_10s"),
+        description: new TM("settings.ips.rate_limit_per_10s.help"))]
+    #[Assert\Range(min: 0, max: 10000)]
+    public int $rateLimitPer10Seconds = 35;
+
+    /**
+     * @var int The maximum number of requests Part-DB sends to a single provider within a minute, or 0 for no limit
+     */
+    #[SettingsParameter(label: new TM("settings.ips.rate_limit_per_minute"),
+        description: new TM("settings.ips.rate_limit_per_minute.help"))]
+    #[Assert\Range(min: 0, max: 60000)]
+    public int $rateLimitPerMinute = 120;
+
+    /**
+     * @var int How long a single request may be delayed by the rate limit before it fails instead, in seconds.
+     * Bulk operations are happy to wait; this keeps an interactive request from hanging indefinitely.
+     */
+    #[SettingsParameter(label: new TM("settings.ips.rate_limit_max_wait"),
+        description: new TM("settings.ips.rate_limit_max_wait.help"))]
+    #[Assert\Range(min: 0, max: 600)]
+    public int $rateLimitMaxWait = 30;
 }

--- a/tests/Services/InfoProviderSystem/InfoProviderRateLimiterTest.php
+++ b/tests/Services/InfoProviderSystem/InfoProviderRateLimiterTest.php
@@ -1,0 +1,136 @@
+<?php
+/*
+ * This file is part of Part-DB (https://github.com/Part-DB/Part-DB-symfony).
+ *
+ *  Copyright (C) 2019 - 2026 Jan Böhmer (https://github.com/jbtronics)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace App\Tests\Services\InfoProviderSystem;
+
+use App\Exceptions\InfoProviderRateLimitExceededException;
+use App\Services\InfoProviderSystem\InfoProviderRateLimiter;
+use App\Settings\InfoProviderSystem\InfoProviderGeneralSettings;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * @see InfoProviderRateLimiter
+ */
+final class InfoProviderRateLimiterTest extends TestCase
+{
+    private function limiter(int $per10s, int $perMinute, int $maxWait): InfoProviderRateLimiter
+    {
+        $settings = new InfoProviderGeneralSettings();
+        $settings->rateLimitPer10Seconds = $per10s;
+        $settings->rateLimitPerMinute = $perMinute;
+        $settings->rateLimitMaxWait = $maxWait;
+
+        return new InfoProviderRateLimiter(new ArrayAdapter(), $settings);
+    }
+
+    public function testRequestsWithinTheLimitPassWithoutDelay(): void
+    {
+        $limiter = $this->limiter(per10s: 3, perMinute: 0, maxWait: 30);
+
+        $start = microtime(true);
+        for ($i = 0; $i < 3; $i++) {
+            $limiter->await('test');
+        }
+
+        self::assertLessThan(1.0, microtime(true) - $start, 'Requests within the limit must not be delayed');
+    }
+
+    public function testExceedingTheLimitFailsAfterTheMaximumWait(): void
+    {
+        //A maximum wait of 0 turns the delay into an immediate error, which keeps this test fast
+        $limiter = $this->limiter(per10s: 2, perMinute: 0, maxWait: 0);
+
+        $limiter->await('test');
+        $limiter->await('test');
+
+        $this->expectException(InfoProviderRateLimitExceededException::class);
+        $limiter->await('test');
+    }
+
+    public function testTheExceptionNamesTheProvider(): void
+    {
+        $limiter = $this->limiter(per10s: 1, perMinute: 0, maxWait: 0);
+        $limiter->await('trustedparts');
+
+        try {
+            $limiter->await('trustedparts');
+            self::fail('Expected the rate limit to be enforced');
+        } catch (InfoProviderRateLimitExceededException $e) {
+            self::assertSame('trustedparts', $e->providerKey);
+            self::assertStringContainsString('trustedparts', $e->getMessage());
+        }
+    }
+
+    public function testTheExceptionIsA429WithARetryAfterHeader(): void
+    {
+        //Hitting the limit is an expected, temporary condition - an automated caller must be able to tell it
+        //apart from a real failure, and to know when to come back
+        $limiter = $this->limiter(per10s: 1, perMinute: 0, maxWait: 0);
+        $limiter->await('test');
+
+        try {
+            $limiter->await('test');
+            self::fail('Expected the rate limit to be enforced');
+        } catch (InfoProviderRateLimitExceededException $e) {
+            self::assertSame(429, $e->getStatusCode());
+            self::assertArrayHasKey('Retry-After', $e->getHeaders());
+            self::assertGreaterThan(0, (int) $e->getHeaders()['Retry-After']);
+            self::assertSame($e->retryAfter, (int) $e->getHeaders()['Retry-After']);
+        }
+    }
+
+    public function testEveryProviderHasItsOwnBudget(): void
+    {
+        //The limits are per provider account, so exhausting one provider must not block another
+        $limiter = $this->limiter(per10s: 1, perMinute: 0, maxWait: 0);
+
+        $limiter->await('trustedparts');
+        $limiter->await('digikey');
+
+        $this->expectException(InfoProviderRateLimitExceededException::class);
+        $limiter->await('digikey');
+    }
+
+    public function testBothWindowsAreEnforced(): void
+    {
+        //Ten per 10 seconds would allow this, but the minute window only permits two
+        $limiter = $this->limiter(per10s: 10, perMinute: 2, maxWait: 0);
+
+        $limiter->await('test');
+        $limiter->await('test');
+
+        $this->expectException(InfoProviderRateLimitExceededException::class);
+        $limiter->await('test');
+    }
+
+    public function testZeroLimitsDisableTheRateLimiting(): void
+    {
+        $limiter = $this->limiter(per10s: 0, perMinute: 0, maxWait: 0);
+
+        for ($i = 0; $i < 50; $i++) {
+            $limiter->await('test');
+        }
+
+        self::assertTrue(true, 'Without configured limits, no request is ever delayed or rejected');
+    }
+}

--- a/tests/State/Mcp/GetInfoProviderPartDetailsProcessorTest.php
+++ b/tests/State/Mcp/GetInfoProviderPartDetailsProcessorTest.php
@@ -28,6 +28,8 @@ use App\Mcp\DTO\InfoProviderPartDetailsInput;
 use App\Services\InfoProviderSystem\DTOs\PartDetailDTO;
 use App\Services\InfoProviderSystem\DTOs\ProviderInfoDTO;
 use App\Services\InfoProviderSystem\DTOtoEntityConverter;
+use App\Services\InfoProviderSystem\InfoProviderRateLimiter;
+use App\Settings\InfoProviderSystem\InfoProviderGeneralSettings;
 use App\Services\InfoProviderSystem\PartInfoRetriever;
 use App\Services\InfoProviderSystem\Providers\InfoProviderInterface;
 use App\Services\InfoProviderSystem\ProviderRegistry;
@@ -63,10 +65,16 @@ final class GetInfoProviderPartDetailsProcessorTest extends TestCase
             SettingsTestHelper::createSettingsDummy(LocalizationSettings::class)
         );
 
+        //These tests do not exercise the provider rate limit, so it is switched off here
+        $rateLimitSettings = SettingsTestHelper::createSettingsDummy(InfoProviderGeneralSettings::class);
+        $rateLimitSettings->rateLimitPer10Seconds = 0;
+        $rateLimitSettings->rateLimitPerMinute = 0;
+
         $this->infoRetriever = new PartInfoRetriever(
             $providerRegistry,
             $dtoToEntityConverter,
             new ArrayAdapter(),
+            new InfoProviderRateLimiter(new ArrayAdapter(), $rateLimitSettings),
             debugMode: true
         );
     }

--- a/tests/State/Mcp/SearchInfoProvidersProcessorTest.php
+++ b/tests/State/Mcp/SearchInfoProvidersProcessorTest.php
@@ -28,6 +28,7 @@ use App\Mcp\DTO\InfoProviderSearchInput;
 use App\Services\InfoProviderSystem\DTOs\ProviderInfoDTO;
 use App\Services\InfoProviderSystem\DTOs\SearchResultDTO;
 use App\Services\InfoProviderSystem\DTOtoEntityConverter;
+use App\Services\InfoProviderSystem\InfoProviderRateLimiter;
 use App\Services\InfoProviderSystem\PartInfoRetriever;
 use App\Services\InfoProviderSystem\Providers\InfoProviderInterface;
 use App\Services\InfoProviderSystem\ProviderRegistry;
@@ -59,10 +60,16 @@ final class SearchInfoProvidersProcessorTest extends TestCase
             SettingsTestHelper::createSettingsDummy(LocalizationSettings::class)
         );
 
+        //These tests do not exercise the provider rate limit, so it is switched off here
+        $rateLimitSettings = SettingsTestHelper::createSettingsDummy(InfoProviderGeneralSettings::class);
+        $rateLimitSettings->rateLimitPer10Seconds = 0;
+        $rateLimitSettings->rateLimitPerMinute = 0;
+
         $this->infoRetriever = new PartInfoRetriever(
             $this->providerRegistry,
             $dtoToEntityConverter,
             new ArrayAdapter(),
+            new InfoProviderRateLimiter(new ArrayAdapter(), $rateLimitSettings),
             debugMode: true
         );
     }

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -15110,5 +15110,41 @@ Buerklin-API Authentication server:
         <target>Edit BOM entry #%id% of project</target>
       </segment>
     </unit>
+    <unit id="ipsRlTen" name="settings.ips.rate_limit_per_10s">
+      <segment state="translated">
+        <source>settings.ips.rate_limit_per_10s</source>
+        <target>Max. provider requests per 10 seconds</target>
+      </segment>
+    </unit>
+    <unit id="ipsRlTenH" name="settings.ips.rate_limit_per_10s.help">
+      <segment state="translated">
+        <source>settings.ips.rate_limit_per_10s.help</source>
+        <target>Part-DB never sends more than this many requests to the same info provider within 10 seconds, and delays further ones. Keep this below the limit of your provider account, especially if an external script uses the same API credentials - the provider counts both. Set to 0 to disable.</target>
+      </segment>
+    </unit>
+    <unit id="ipsRlMin" name="settings.ips.rate_limit_per_minute">
+      <segment state="translated">
+        <source>settings.ips.rate_limit_per_minute</source>
+        <target>Max. provider requests per minute</target>
+      </segment>
+    </unit>
+    <unit id="ipsRlMinH" name="settings.ips.rate_limit_per_minute.help">
+      <segment state="translated">
+        <source>settings.ips.rate_limit_per_minute.help</source>
+        <target>The same, for a one minute window. Set to 0 to disable.</target>
+      </segment>
+    </unit>
+    <unit id="ipsRlWait" name="settings.ips.rate_limit_max_wait">
+      <segment state="translated">
+        <source>settings.ips.rate_limit_max_wait</source>
+        <target>Max. wait for a free slot</target>
+      </segment>
+    </unit>
+    <unit id="ipsRlWaitH" name="settings.ips.rate_limit_max_wait.help">
+      <segment state="translated">
+        <source>settings.ips.rate_limit_max_wait.help</source>
+        <target>How long a single request may be delayed by the limits above before it fails instead, in seconds. Bulk operations simply wait; this keeps a request started from the user interface from hanging.</target>
+      </segment>
+    </unit>
   </file>
 </xliff>


### PR DESCRIPTION
Info providers limit requests per account, usually in short windows - TrustedParts, for example,
allows 50 requests per 10 seconds and 150 per minute - and many of them bill per request.
Part-DB can easily produce bursts above that: a bulk import, or an update of many parts, walks
through them as fast as the network allows with nothing in between.

Worse, the limit belongs to the account, not to Part-DB. A script maintaining parts through the
API uses the same credentials, so its requests and Part-DB's add up while neither side can see
the other's count. Coordinating the two by hand is the only remedy today, and it fails the moment
somebody clicks "update from info provider" while a job is running.

Part-DB now paces itself. Two sliding windows per provider are enforced in PartInfoRetriever,
inside the cache callbacks - the single point every provider request passes, and the only place
where a cache hit can be told apart from a request that really goes out. The counters live in the
shared cache pool, so web requests, console commands and background jobs all count against the
same budget.

Requests are delayed, not rejected: a bulk operation simply takes longer, which is what it wants.
Only if a single request would wait longer than the configured maximum does it fail, with HTTP 429
and a Retry-After header naming the seconds until the next free slot, so an automated caller can
tell "too fast, come back shortly" apart from a real error.

The defaults (35 per 10 seconds, 120 per minute, 30 seconds maximum wait) stay deliberately below
what providers permit: the remaining headroom is what keeps Part-DB and an external script sharing
the account from pushing each other over the real limit. Each window can be switched off by
setting it to 0.

Two limitations worth naming. The counter updates are not synchronized - symfony/lock is not a
dependency - so parallel processes can slightly under-count, which is why the configured limit
should stay below the provider's own. And a provider with an internal cache of its own consumes a
slot even when it answers from that cache, which errs on the safe side.

This is the follow-up I offered in #1532.