### PR TITLE
Make the AI extraction schema valid for strict structured outputs

### DIFF
--- a/src/Services/InfoProviderSystem/DTOJsonSchemaConverter.php
+++ b/src/Services/InfoProviderSystem/DTOJsonSchemaConverter.php
@@ -41,7 +41,7 @@ final class DTOJsonSchemaConverter
      */
     public function getJSONSchema(): array
     {
-        return [
+        $schema = [
             'name' => 'part_detail',
             'strict' => true,
             'schema' => [
@@ -127,6 +127,39 @@ final class DTOJsonSchemaConverter
                 'required' => ['name', 'description'],
             ]
         ];
+
+        //The schema is written out above for readability; the rules of the strict mode are applied here, so
+        //that they cannot be forgotten when a property is added later
+        $schema['schema'] = $this->applyStrictModeRules($schema['schema']);
+
+        return $schema;
+    }
+
+    /**
+     * Applies the two rules a schema has to follow to be accepted in strict mode.
+     *
+     * Providers of the OpenAI family reject a strict schema unless every object forbids additional properties
+     * and lists all of its properties as required - an optional value is expressed by allowing null in its type
+     * instead, which is what the schema above already does. Without this the whole extraction fails with
+     * "Invalid schema for response_format", and through a gateway that arrives as an unspecific
+     * "Provider returned error".
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    private function applyStrictModeRules(array $schema): array
+    {
+        if (($schema['type'] ?? null) === 'object' && isset($schema['properties']) && is_array($schema['properties'])) {
+            $schema['properties'] = array_map($this->applyStrictModeRules(...), $schema['properties']);
+            $schema['additionalProperties'] = false;
+            $schema['required'] = array_keys($schema['properties']);
+        }
+
+        if (isset($schema['items']) && is_array($schema['items'])) {
+            $schema['items'] = $this->applyStrictModeRules($schema['items']);
+        }
+
+        return $schema;
     }
 
     public function jsonToDTO(array $data, string $providerKey, string $providerId, ?string $productUrl = null, string $distributorNameFallback = '???'): PartDetailDTO

--- a/tests/Services/InfoProviderSystem/DTOJsonSchemaConverterTest.php
+++ b/tests/Services/InfoProviderSystem/DTOJsonSchemaConverterTest.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ * This file is part of Part-DB (https://github.com/Part-DB/Part-DB-symfony).
+ *
+ *  Copyright (C) 2019 - 2026 Jan Böhmer (https://github.com/jbtronics)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace App\Tests\Services\InfoProviderSystem;
+
+use App\Services\InfoProviderSystem\DTOJsonSchemaConverter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see DTOJsonSchemaConverter
+ */
+final class DTOJsonSchemaConverterTest extends TestCase
+{
+    /**
+     * Collects every object of the schema, keyed by a readable path, so that a violation names the place.
+     *
+     * @param  array<string, mixed>  $node
+     * @return array<string, array<string, mixed>>
+     */
+    private function objectsOf(array $node, string $path = 'root'): array
+    {
+        $objects = [];
+
+        if (($node['type'] ?? null) === 'object' && isset($node['properties'])) {
+            $objects[$path] = $node;
+
+            foreach ($node['properties'] as $name => $property) {
+                if (is_array($property)) {
+                    $objects += $this->objectsOf($property, $path.'.'.$name);
+                }
+            }
+        }
+
+        if (isset($node['items']) && is_array($node['items'])) {
+            $objects += $this->objectsOf($node['items'], $path.'[]');
+        }
+
+        return $objects;
+    }
+
+    public function testTheSchemaIsAcceptedInStrictMode(): void
+    {
+        //The schema is sent with strict: true, and a provider of the OpenAI family rejects the whole request
+        //unless every object forbids additional properties and lists all of its properties as required. Through
+        //a gateway that rejection arrives as an unspecific "Provider returned error", so it is worth pinning
+        //down here rather than finding out at runtime.
+        $schema = (new DTOJsonSchemaConverter())->getJSONSchema();
+
+        self::assertTrue($schema['strict'], 'The schema is sent as a strict one');
+
+        $objects = $this->objectsOf($schema['schema']);
+        self::assertGreaterThan(1, count($objects), 'The schema is expected to contain nested objects');
+
+        foreach ($objects as $path => $object) {
+            self::assertFalse($object['additionalProperties'] ?? null,
+                sprintf('%s has to forbid additional properties', $path));
+            self::assertSame(array_keys($object['properties']), $object['required'] ?? [],
+                sprintf('%s has to list all of its properties as required', $path));
+        }
+    }
+
+    public function testOptionalValuesStayExpressibleAsNull(): void
+    {
+        //Making everything required is only acceptable because an optional value says so through its type
+        $schema = (new DTOJsonSchemaConverter())->getJSONSchema();
+        $properties = $schema['schema']['properties'];
+
+        self::assertContains('null', (array) $properties['manufacturer']['type']);
+        self::assertContains('null', (array) $properties['mpn']['type']);
+    }
+}


### PR DESCRIPTION
The schema which the AI extractor sends along with its request is declared as a strict one (`'strict' => true`
in `DTOJsonSchemaConverter`), but it does not follow the two rules a schema has to follow to be accepted as
such: every object must forbid additional properties, and must list all of its properties as required. A
provider of the OpenAI family therefore refuses the request outright:

    Invalid schema for response_format 'part_detail': In context=('properties', 'parameters', 'items'),
    'additionalProperties' is required to be supplied and to be false.
    ("type":"invalid_request_error", "code":"invalid_json_schema", provider_name: Azure)

Which means the AI extractor cannot work with those models at all - "Create part from URL" fails every time.
Going through a gateway makes it harder to see: OpenRouter answers with its own "Provider returned error" and
keeps the reason in a field which is not part of the exception, so the failure looks like a misconfiguration on
the user's side. (I only got at the message above with #1539; the two are otherwise independent.)

Rather than sprinkling the two rules over a nested array literal, they are applied to the finished schema by
walking it. The schema stays as readable as it is now, and a property added later cannot forget them.

Requiring every property is only acceptable because the schema already expresses an optional value by allowing
null in its type, which the second test pins down alongside the rules themselves.

Verified on a real instance: with this change the extraction runs through against `openai/gpt-5.6-luna` via
OpenRouter, where it failed on every attempt before.
