### PR TITLE
fix(mcp): gate the read-only get_part_details tool with read permission

### DIFF
--- a/src/Entity/Parts/Part.php
+++ b/src/Entity/Parts/Part.php
@@ -154,7 +154,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
                 'groups' => ['part:read', 'provider_reference:read', 'api:basic:read', 'part_lot:read', 'orderdetail:read', 'pricedetail:read', 'parameter:read', 'attachment:read', 'eda_info:read'],
                 'item_uri_template' => '/api/parts/{id}',
             ],
-            security: 'is_granted("edit", object)',
+            security: 'is_granted("@parts.read")',
             input: ElementByIdInput::class,
             validate: true,
             processor: GetPartByIdProcessor::class

--- a/tests/State/Mcp/ReadOnlyMcpToolsUseReadSecurityTest.php
+++ b/tests/State/Mcp/ReadOnlyMcpToolsUseReadSecurityTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Part-DB (https://github.com/Part-DB/Part-DB-symfony).
+ *
+ *  Copyright (C) 2019 - 2026 Jan Böhmer (https://github.com/jbtronics)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Tests\State\Mcp;
+
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use App\Entity\Parts\Part;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Any MCP tool on the Part resource that declares itself read-only
+ * (`annotations: ['readOnlyHint' => true, ...]`) must be gated with a read
+ * permission expression (e.g. `is_granted("@parts.read")`), never with a
+ * mutating permission like `edit`, `create` or `delete`.
+ *
+ * Background: ApiPlatform/MCP enforces each tool's `security` expression on
+ * `tools/call` without a subject object bound, so an expression such as
+ * `is_granted("edit", object)` can never resolve the Part and always denies
+ * with "Access Denied" — even for users with full Part permissions. The
+ * per-object read check already happens inside the tool's processor (e.g.
+ * GetPartByIdProcessor), so the declared security must only require the
+ * collection-level read permission, just like the sibling read-only tools.
+ *
+ * This is a regression test for exactly that bug (get_part_details was
+ * declared with the update_part mutation expression): it inspects the
+ * registered ApiPlatform metadata for the Part resource (the same metadata
+ * the MCP server enforces), not just what the processor checks in isolation —
+ * unit/functional tests calling the processor directly cannot catch this
+ * class of bug.
+ */
+class ReadOnlyMcpToolsUseReadSecurityTest extends KernelTestCase
+{
+    /**
+     * @return array<string, object>
+     */
+    private static function getPartMcpTools(): array
+    {
+        self::bootKernel();
+        $factory = self::getContainer()->get(ResourceMetadataCollectionFactoryInterface::class);
+        $collection = $factory->create(Part::class);
+
+        $tools = null;
+        foreach ($collection as $resource) {
+            if (null !== ($mcp = $resource->getMcp())) {
+                $tools = $mcp;
+                break;
+            }
+        }
+        self::assertNotNull($tools, 'The Part resource should expose MCP tools');
+
+        return $tools;
+    }
+
+    public function testReadOnlyToolsDoNotRequireMutatingPermission(): void
+    {
+        $tools = self::getPartMcpTools();
+
+        $readOnlyTools = [];
+        foreach ($tools as $name => $tool) {
+            $annotations = $tool->getAnnotations();
+            if (\is_array($annotations) && ($annotations['readOnlyHint'] ?? null) === true) {
+                $readOnlyTools[$name] = $tool;
+            }
+        }
+
+        self::assertNotEmpty($readOnlyTools, 'The Part resource should expose read-only MCP tools');
+
+        foreach ($readOnlyTools as $name => $tool) {
+            $security = $tool->getSecurity() ?? '';
+            foreach (['edit', 'create', 'delete'] as $forbidden) {
+                self::assertStringNotContainsStringIgnoringCase(
+                    $forbidden,
+                    $security,
+                    sprintf(
+                        'Read-only MCP tool "%s" must not require "%s" permission (security: "%s"). '
+                        .'Read-only tools are enforced without a subject object, so only a read gate such as '
+                        .'is_granted("@parts.read") works here; the per-object check lives in the processor.',
+                        $name,
+                        $forbidden,
+                        $security
+                    )
+                );
+            }
+        }
+    }
+
+    public function testGetPartDetailsUsesReadSecurity(): void
+    {
+        $tools = self::getPartMcpTools();
+
+        self::assertArrayHasKey('get_part_details', $tools, 'The Part resource should expose a get_part_details MCP tool');
+        self::assertSame(
+            'is_granted("@parts.read")',
+            $tools['get_part_details']->getSecurity(),
+            'get_part_details is read-only and must stay aligned with its sibling read-only tools '
+            .'(search_parts, advanced_search_parts, get_part_preview_image).'
+        );
+    }
+}


### PR DESCRIPTION
## What

`get_part_details` is a read-only MCP tool, but its `McpTool` attribute was declared with the *mutating* permission expression `is_granted("edit", object)` — the same one used by `update_part`.

## Why it was broken

ApiPlatform/MCP enforces a tool's `security` expression on `tools/call` via `ExpressionAccessChecker` + `ResourceAccessChecker`. For an MCP tool there is no subject object bound, so `is_granted("edit", object)` can never resolve a `Part` and always denies with "Access Denied", while the sibling read-only tools (`search_parts`, `advanced_search_parts`, `get_part_preview_image`) that use `is_granted("@parts.read")` work fine.

That matches the report in #1545 exactly: search and the preview image work, `get_part_details` is denied even for a user whose effective Part/View and Part/Edit permissions are both Allow.

The per-object check is not lost by this change: `GetPartByIdProcessor` already performs

```php
if (!$this->authorizationChecker->isGranted('read', $part)) {
    throw new AccessDeniedException(sprintf('Access denied to part with id %d', $data->id));
}
```

before returning the part — the identical check its working sibling `GetPartPreviewImageProcessor` uses. The declared tool security only needs to express the collection-level gate, which is why every other read-only tool on this resource uses `@parts.read`.

## How

One line in `src/Entity/Parts/Part.php`: `get_part_details`'s `security` is aligned with the other read-only tools → `is_granted("@parts.read")`. No other tool is touched — `create_part`, `update_part` and `delete_part` keep their mutating expressions.

## Tests

New `tests/State/Mcp/ReadOnlyMcpToolsUseReadSecurityTest.php` (KernelTestCase, same approach as the existing `CallToolResultToolsDeclareNoOutputSchemaTest`). It inspects the registered ApiPlatform metadata of the Part resource — the same metadata the MCP server enforces — and

* asserts the rule that every tool annotated `readOnlyHint: true` must not be gated by an `edit`/`create`/`delete` expression (this catches the whole class of bug, not just this instance);
* pins `get_part_details` to `is_granted("@parts.read")`.

Results (PHP 8.3.6, PHPUnit 11.5):

* `./bin/phpunit tests/State/Mcp/ReadOnlyMcpToolsUseReadSecurityTest.php` → OK (2 tests, 17 assertions)
* `./bin/phpunit tests/State/Mcp/` → OK (140 tests, 673 assertions)
* Mutation check: reverting only the one-line production fix makes both new tests fail with `-'is_granted("@parts.read")' / +'is_granted("edit", object)'`; restoring it turns them green again — so the test really guards this fix.

Fixes #1545

*(This change was implemented with AI assistance (OpenCode + muse-spark-1.3) and then reviewed, tested and mutation-checked by hand.)*
